### PR TITLE
Delay initial infection times on colors and cerberon

### DIFF
--- a/mapcfg/ze_colors_p.cfg
+++ b/mapcfg/ze_colors_p.cfg
@@ -1,0 +1,2 @@
+zr_infect_spawn_time_min 17
+zr_infect_spawn_time_max 17

--- a/mapcfg/ze_descent_into_cerberon_p.cfg
+++ b/mapcfg/ze_descent_into_cerberon_p.cfg
@@ -1,0 +1,2 @@
+zr_infect_spawn_time_min 17
+zr_infect_spawn_time_max 17


### PR DESCRIPTION
Delay infection time by 2 seconds so that mother zombies do not spawn directly on top of CTs.