### PR TITLE
Add entwatch configs for several maps

### DIFF
--- a/entwatch/ze_8bit.jsonc
+++ b/entwatch/ze_8bit.jsonc
@@ -1,0 +1,149 @@
+[
+    {
+        "name": "Ammo",
+        "shortname": "Ammo",
+        "hammerid": "5594",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "orange",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5595",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Fire",
+        "shortname": "Fire",
+        "hammerid": "5038",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5039",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Mines",
+        "shortname": "Mines",
+        "hammerid": "5019",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5020",
+                "event": "OnPressed",
+                "mode": 4,
+                "cooldown": 10,
+                "maxuses": 8,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Stopper",
+        "shortname": "Stopper",
+        "hammerid": "4988",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4989",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Cannon Ultimate",
+        "shortname": "Ultimate",
+        "hammerid": "4970",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4968",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Electro",
+        "shortname": "Electro",
+        "hammerid": "4739",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4740",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 50,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Heal",
+        "shortname": "Heal",
+        "hammerid": "4733",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "white",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4734",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_arcana_heart.jsonc
+++ b/entwatch/ze_arcana_heart.jsonc
@@ -1,0 +1,174 @@
+[
+    {
+        "name": "Gravity",
+        "shortname": "Gravity",
+        "hammerid": "2845",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "yellow",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2848",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Cube",
+        "shortname": "ZM Cube",
+        "hammerid": "2941",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "yellow",
+        "triggers": ["2008"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3697",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Heal",
+        "shortname": "Heal",
+        "hammerid": "3169",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2857",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 80,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Water",
+        "shortname": "ZM Water",
+        "hammerid": "2958",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "blue",
+        "triggers": ["2735"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2728",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Heal",
+        "shortname": "ZM Heal",
+        "hammerid": "4570",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["3268"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4356",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 50,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Push",
+        "shortname": "Push",
+        "hammerid": "4310",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2511",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 50,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Reverse",
+        "shortname": "ZM Reverse",
+        "hammerid": "2029",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "purple",
+        "triggers": ["999"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4353",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 80,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Shield",
+        "shortname": "Shield",
+        "hammerid": "3792",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2690",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 80,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_azathoth_p.jsonc
+++ b/entwatch/ze_azathoth_p.jsonc
@@ -1,0 +1,23 @@
+[
+    {
+        "name": "Sword",
+        "shortname": "Sword",
+        "hammerid": "287",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "285",
+                "event": "OnPressed",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_backrooms_deathbed_v1.jsonc
+++ b/entwatch/ze_backrooms_deathbed_v1.jsonc
@@ -1,0 +1,44 @@
+[
+    {
+        "name": "Tactical Flashlight 1",
+        "shortname": "Flashlight 1",
+        "hammerid": "5687",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "white",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5700",
+                "event": "OnPressed",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Tactical Flashlight 2",
+        "shortname": "Flashlight 2",
+        "hammerid": "5709",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "white",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5723",
+                "event": "OnPressed",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_backrooms_deathbed_v1.jsonc
+++ b/entwatch/ze_backrooms_deathbed_v1.jsonc
@@ -1,3 +1,5 @@
+// Flashlight cooldown/charge is based on a counter
+// Waiting on mode 6/7 implementation before updating cfg
 [
     {
         "name": "Tactical Flashlight 1",

--- a/entwatch/ze_biohazard2_rpd_004_p.jsonc
+++ b/entwatch/ze_biohazard2_rpd_004_p.jsonc
@@ -1,0 +1,23 @@
+[
+    {
+        "name": "Rocket Launcher",
+        "shortname": "Rocket",
+        "hammerid": "357",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "110",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 1,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_biohazard_manor_004_p.jsonc
+++ b/entwatch/ze_biohazard_manor_004_p.jsonc
@@ -1,0 +1,23 @@
+[
+    {
+        "name": "Flamethrower",
+        "shortname": "Flamethrower",
+        "hammerid": "974",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "orange",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "978",
+                "event": "OnPlayerUse",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_christmas_p.jsonc
+++ b/entwatch/ze_christmas_p.jsonc
@@ -1,0 +1,44 @@
+[
+    {
+        "name": "Heal",
+        "shortname": "Heal",
+        "hammerid": "134",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "139",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 45,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Gravity",
+        "shortname": "Gravity",
+        "hammerid": "147",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "purple",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "153",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 75,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_death_star_escape_p.jsonc
+++ b/entwatch/ze_death_star_escape_p.jsonc
@@ -1,0 +1,44 @@
+[
+    {
+        "name": "Blue Lightsaber",
+        "shortname": "Lightsaber",
+        "hammerid": "1622",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1614",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 20,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Red Lightsaber",
+        "shortname": "Lightsaber",
+        "hammerid": "1820",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "darkred",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1810",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 20,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_farmhouse_p.jsonc
+++ b/entwatch/ze_farmhouse_p.jsonc
@@ -1,0 +1,130 @@
+// Push gun, Ice gun, and Barricade have dynamic uses based on math_counter
+// Waiting for mode 6/7 implementation before updating cfg
+[
+    {
+        "name": "Zombie Tank",
+        "shortname": "ZM Tank",
+        "hammerid": "28353",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "darkred",
+        "triggers": ["28356"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "28343",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 7,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "game_ui",
+                "hammerid": "28358",
+                "event": "OnCase16",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "game_ui",
+                "hammerid": "28358",
+                "event": "OnCase15",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Barricade",
+        "shortname": "Barricade",
+        "hammerid": "969",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "grey",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "6047",
+                "event": "OnPressed",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Push Gun",
+        "shortname": "Push",
+        "hammerid": "770",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "6039",
+                "event": "OnPressed",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Ice Gun",
+        "shortname": "Ice",
+        "hammerid": "430",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5977",
+                "event": "OnPressed",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Plasma Beam Cannon",
+        "shortname": "Plasma",
+        "hammerid": "28388",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "28396",
+                "event": "OnPressed",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_forsaken_temple.jsonc
+++ b/entwatch/ze_forsaken_temple.jsonc
@@ -1,0 +1,293 @@
+[
+    {
+        "name": "Heal Magic",
+        "shortname": "Heal",
+        "hammerid": "3329",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "white",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3327",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 80,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Electro Magic",
+        "shortname": "Electro",
+        "hammerid": "3308",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "yellow",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3306",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 90,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Water Magic",
+        "shortname": "Water",
+        "hammerid": "3318",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3316",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 90,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Fire Magic",
+        "shortname": "Fire",
+        "hammerid": "3298",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3296",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 75,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Earth Magic",
+        "shortname": "Earth",
+        "hammerid": "3291",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "olive",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3289",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 90,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Tornado Magic",
+        "shortname": "Tornado",
+        "hammerid": "3280",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3278",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 90,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Gravity Magic",
+        "shortname": "Gravity",
+        "hammerid": "3270",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "purple",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3268",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 90,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Heal",
+        "shortname": "ZM Heal",
+        "hammerid": "3232",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["3227"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3230",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 30,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Beam",
+        "shortname": "ZM Beam",
+        "hammerid": "3240",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "yellow",
+        "triggers": ["3243"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3238",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 45,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Gravity",
+        "shortname": "ZM Gravity",
+        "hammerid": "3256",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "purple",
+        "triggers": ["3252"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3254",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 80,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Fruit of Knowledge",
+        "shortname": "Fruit",
+        "hammerid": "3035",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "purple"
+    },
+    {
+        "name": "Flame of Magic",
+        "shortname": "Flame",
+        "hammerid": "3029",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red"
+    },
+    {
+        "name": "Holy Magic",
+        "shortname": "Holy",
+        "hammerid": "1669",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "pink",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1665",
+                "event": "OnPressed",
+                "mode": 4,
+                "cooldown": 1,
+                "maxuses": 15,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Ammo Magic",
+        "shortname": "Ammo",
+        "hammerid": "1627",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "gold",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1623",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 90,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "The Bait",
+        "shortname": "Bait",
+        "hammerid": "1548",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "grey"
+    },
+    {
+        "name": "Temple Key",
+        "shortname": "Key",
+        "hammerid": "2554",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "yellow"
+    }
+]

--- a/entwatch/ze_gods_wrath_p.jsonc
+++ b/entwatch/ze_gods_wrath_p.jsonc
@@ -1,0 +1,65 @@
+[
+    {
+        "name": "Burner Gun",
+        "shortname": "Burner",
+        "hammerid": "688",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "orange",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "711",
+                "event": "OnPressed",
+                "mode": 20,
+                "cooldown": 40,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Fire Bow 1",
+        "shortname": "Bow 1",
+        "hammerid": "716",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "orange",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "714",
+                "event": "OnPressed",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Fire Bow 2",
+        "shortname": "Bow 2",
+        "hammerid": "813",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "orange",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "808",
+                "event": "OnPressed",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_grau_p.jsonc
+++ b/entwatch/ze_grau_p.jsonc
@@ -16,7 +16,7 @@
         "ui": true,
         "transfer": false,
         "color": "grey",
-        "triggers": ["431", "907", "909", "429"],
+        "triggers": ["431"],
         "handlers": [
             {
                 "type": "game_ui",
@@ -38,7 +38,7 @@
         "ui": true,
         "transfer": false,
         "color": "grey",
-        "triggers": ["431", "907", "909", "429"],
+        "triggers": ["907"],
         "handlers": [
             {
                 "type": "game_ui",
@@ -70,7 +70,7 @@
         "ui": true,
         "transfer": false,
         "color": "grey",
-        "triggers": ["431", "907", "909", "429"],
+        "triggers": ["909", "429"],
         "handlers": [
             {
                 "type": "game_ui",

--- a/entwatch/ze_grau_p.jsonc
+++ b/entwatch/ze_grau_p.jsonc
@@ -64,7 +64,7 @@
     },
     {
         "name": "Zombie Speed",
-        "shortname": "ZM SPeed",
+        "shortname": "ZM Speed",
         "hammerid": "11690",
         "message": true,
         "ui": true,

--- a/entwatch/ze_grau_p.jsonc
+++ b/entwatch/ze_grau_p.jsonc
@@ -1,0 +1,97 @@
+[
+    {
+        "name": "Outline",
+        "shortname": "Outline",
+        "hammerid": "679",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "white"
+    },
+    {
+        "name": "Zombie Slow 1",
+        "shortname": "ZM Slow 1",
+        "hammerid": "11685",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "grey",
+        "triggers": ["431", "907", "909", "429"],
+        "handlers": [
+            {
+                "type": "game_ui",
+                "hammerid": "11683",
+                "event": "OnCase16",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Slow 2",
+        "shortname": "ZM Slow 2",
+        "hammerid": "11688",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "grey",
+        "triggers": ["431", "907", "909", "429"],
+        "handlers": [
+            {
+                "type": "game_ui",
+                "hammerid": "11689",
+                "event": "OnCase15",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "game_ui",
+                "hammerid": "11689",
+                "event": "OnCase16",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Speed",
+        "shortname": "ZM SPeed",
+        "hammerid": "11690",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "grey",
+        "triggers": ["431", "907", "909", "429"],
+        "handlers": [
+            {
+                "type": "game_ui",
+                "hammerid": "11691",
+                "event": "OnCase15",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "game_ui",
+                "hammerid": "11691",
+                "event": "OnCase16",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_mirrors_edge_reborn_p.jsonc
+++ b/entwatch/ze_mirrors_edge_reborn_p.jsonc
@@ -1,0 +1,23 @@
+[
+    {
+        "name": "Unlimited Ammo",
+        "shortname": "Ammo",
+        "hammerid": "2852",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2885",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 65,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_mist_p.jsonc
+++ b/entwatch/ze_mist_p.jsonc
@@ -1,0 +1,128 @@
+[
+    {
+        "name": "Cleansing Aura",
+        "shortname": "Aura",
+        "hammerid": "1072",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "pink",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1073",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Static Field",
+        "shortname": "Static",
+        "hammerid": "1065",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "olive",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1063",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 10,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Toxic Haze",
+        "shortname": "Toxic",
+        "hammerid": "1079",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1081",
+                "event": "OnPressed",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Spirit Burst",
+        "shortname": "Burst",
+        "hammerid": "1051",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "white",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1052",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 10,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Acid Flame",
+        "shortname": "Flame",
+        "hammerid": "1044",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "orange",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1045",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 10,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Ice Nova",
+        "shortname": "Ice",
+        "hammerid": "1037",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1038",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 10,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_platformer_p.jsonc
+++ b/entwatch/ze_platformer_p.jsonc
@@ -1,0 +1,237 @@
+[
+    {
+        "name": "Rocket Launcher",
+        "shortname": "Rocket",
+        "hammerid": "3688",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["3705"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3695",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 5,
+                "maxuses": 0,
+                "message": false,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Mines",
+        "shortname": "Mines",
+        "hammerid": "3672",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "darkred",
+        "triggers": ["3676"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3660",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 5,
+                "message": false,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Earth Builder",
+        "shortname": "ZM Builder",
+        "hammerid": "3637",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "olive",
+        "triggers": ["3652"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3639",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 13,
+                "message": false,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Ladder",
+        "shortname": "Ladder",
+        "hammerid": "3625",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "grey",
+        "triggers": ["3629"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3616",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 20,
+                "maxuses": 0,
+                "message": false,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Flamethrower", // Mode 6 with 3600 math_counter ID
+        "shortname": "Flamethrower",
+        "hammerid": "3601",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "orange",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3595",
+                "event": "OnPressed",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": false,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Trampoline",
+        "shortname": "Trampoline",
+        "hammerid": "3578",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "olive",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3580",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 20,
+                "maxuses": 0,
+                "message": false,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Coin Gun",
+        "shortname": "Coin",
+        "hammerid": "3558",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "yellow",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3549",
+                "event": "OnPressed",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": false,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Microsoft Firewall",
+        "shortname": "Firewall",
+        "hammerid": "3507",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "orange",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3509",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 15,
+                "maxuses": 0,
+                "message": false,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Earth Builder",
+        "shortname": "Builder",
+        "hammerid": "3490",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "olive",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3504",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 10,
+                "message": false,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Jetpack",
+        "shortname": "Jetpack",
+        "hammerid": "3453",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3456",
+                "event": "OnPressed",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": false,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Push Gun",
+        "shortname": "Push",
+        "hammerid": "3438",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3436",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 40,
+                "maxuses": 0,
+                "message": false,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_potc_p.jsonc
+++ b/entwatch/ze_potc_p.jsonc
@@ -1,0 +1,23 @@
+[
+    {
+        "name": "Jack's Pistol",
+        "shortname": "Pistol",
+        "hammerid": "122",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "661",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_predator_ultimate_p.jsonc
+++ b/entwatch/ze_predator_ultimate_p.jsonc
@@ -1,0 +1,221 @@
+[
+    {
+        "name": "Gauss Rifle",
+        "shortname": "Gauss",
+        "hammerid": "19515",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "19622",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 100,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Impulsor",
+        "shortname": "Impulsor",
+        "hammerid": "19605",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "purple"
+    },
+    {
+        "name": "Push Gun",
+        "shortname": "Push",
+        "hammerid": "19569",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "19573",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 15,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Alien Device",
+        "shortname": "Device",
+        "hammerid": "19560",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "darkred",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "19558",
+                "event": "OnPlayerUse",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Flamethrower",
+        "shortname": "Flamethrower",
+        "hammerid": "19553",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "orange",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "19550",
+                "event": "OnPlayerUse",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Alien Sample",
+        "shortname": "Sample",
+        "hammerid": "19535",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "19420",
+                "event": "OnPlayerUse",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Minigun",
+        "shortname": "Minigun",
+        "hammerid": "19531",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "grey",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "19529",
+                "event": "OnPlayerUse",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Ammo Dispenser",
+        "shortname": "Ammo",
+        "hammerid": "19734",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "olive",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "19511",
+                "event": "OnPlayerUse",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Claymore Mines",
+        "shortname": "Mines",
+        "hammerid": "19465",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "darkred",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "19462",
+                "event": "OnPlayerUse",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 10,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Grenade Launcher",
+        "shortname": "Launcher",
+        "hammerid": "19443",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "darkred",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "19444",
+                "event": "OnPlayerUse",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 18,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "First Aid",
+        "shortname": "Heal",
+        "hammerid": "19424",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "19410",
+                "event": "OnPlayerUse",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_shroomforest2_p.jsonc
+++ b/entwatch/ze_shroomforest2_p.jsonc
@@ -1,0 +1,236 @@
+[
+    {
+        "name": "Zombie Shroom",
+        "shortname": "ZM Shroom",
+        "hammerid": "6355",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "green",
+        "triggers": ["8532"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "6352",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 75,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Cloud",
+        "shortname": "ZM Cloud",
+        "hammerid": "6349",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "grey",
+        "triggers": ["8530"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "6345",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 75,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Ammo",
+        "shortname": "Ammo",
+        "hammerid": "6170",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "olive",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "6165",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Water",
+        "shortname": "Water",
+        "hammerid": "5982",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5980",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Mines",
+        "shortname": "Mines",
+        "hammerid": "5774",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "grey",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5777",
+                "event": "OnPlayerUse",
+                "mode": 4,
+                "cooldown": 4,
+                "maxuses": 6,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Gravity",
+        "shortname": "Gravity",
+        "hammerid": "5468",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "purple",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5469",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Wind",
+        "shortname": "Wind",
+        "hammerid": "5471",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5472",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Ice",
+        "shortname": "Ice",
+        "hammerid": "5486",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5488",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Earth",
+        "shortname": "Earth",
+        "hammerid": "5456",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "triggers": [""],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5458",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Heal",
+        "shortname": "Heal",
+        "hammerid": "5478",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5476",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Fire",
+        "shortname": "Fire",
+        "hammerid": "5451",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "orange",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5452",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_shroomforest_p.jsonc
+++ b/entwatch/ze_shroomforest_p.jsonc
@@ -148,8 +148,8 @@
                 "type": "button",
                 "hammerid": "1132",
                 "event": "OnPlayerUse",
-                "mode": 3,
-                "cooldown": 0,
+                "mode": 4,
+                "cooldown": 4,
                 "maxuses": 6,
                 "message": true,
                 "ui": true

--- a/entwatch/ze_shroomforest_p.jsonc
+++ b/entwatch/ze_shroomforest_p.jsonc
@@ -1,0 +1,210 @@
+[
+    {
+        "name": "Unlimited Ammo",
+        "shortname": "Ammo",
+        "hammerid": "1058",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "olive",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1056",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Ice",
+        "shortname": "Ice",
+        "hammerid": "1209",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1201",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Wind",
+        "shortname": "Wind",
+        "hammerid": "1197",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1192",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Gravity",
+        "shortname": "Gravity",
+        "hammerid": "1189",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "gravity",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1183",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Fire",
+        "shortname": "Fire",
+        "hammerid": "1179",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "orange",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1173",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Key",
+        "shortname": "Key",
+        "hammerid": "1166",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "olive"
+    },
+    {
+        "name": "Earth",
+        "shortname": "Earth",
+        "hammerid": "1156",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "triggers": [""],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1149",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Mines",
+        "shortname": "Mines",
+        "hammerid": "1143",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "grey",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1132",
+                "event": "OnPlayerUse",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 6,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Heal",
+        "shortname": "Heal",
+        "hammerid": "1126",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1121",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Gear Mechanism",
+        "shortname": "Gear",
+        "hammerid": "8030",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "olive"
+    },
+    {
+        "name": "Ultimate Weapon",
+        "shortname": "Ultima",
+        "hammerid": "914",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "darkred",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "917",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 75,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_slender_escape_p.jsonc
+++ b/entwatch/ze_slender_escape_p.jsonc
@@ -1,0 +1,213 @@
+[
+    {
+        "name": "Zombie Fire Slender",
+        "shortname": "ZM Slender",
+        "hammerid": "1257",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "orange",
+        "triggers": ["1259"],
+        "handlers": [
+            {
+                "type": "game_ui",
+                "hammerid": "9854",
+                "event": "OnCase16",
+                "mode": 2,
+                "cooldown": 20,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Monkey Bomb",
+        "shortname": "Bomb",
+        "hammerid": "1114",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "darkred",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1115",
+                "event": "OnPlayerUse",
+                "mode": 4,
+                "cooldown": 13,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Spider",
+        "shortname": "ZM Spider",
+        "hammerid": "1059",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "grey",
+        "triggers": ["1057"],
+        "handlers": [
+            {
+                "type": "game_ui",
+                "hammerid": "9851",
+                "event": "OnCase15",
+                "mode": 2,
+                "cooldown": 10,
+                "maxuses": 0,
+                "message": false,
+                "ui": true
+            },
+            {
+                "type": "game_ui",
+                "hammerid": "9851",
+                "event": "OnCase16",
+                "mode": 2,
+                "cooldown": 20,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Barrel",
+        "shortname": "ZM Barrel",
+        "hammerid": "595",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "grey",
+        "triggers": ["596"],
+        "handlers": [
+            {
+                "type": "game_ui",
+                "hammerid": "9855",
+                "event": "OnCase15",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "game_ui",
+                "hammerid": "9855",
+                "event": "OnCase16",
+                "mode": 2,
+                "cooldown": 30,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Fuel Can",
+        "shortname": "Fuel",
+        "hammerid": "436",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red"
+    },
+    {
+        "name": "Lantern",
+        "shortname": "Lantern",
+        "hammerid": "252",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "yellow",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "250",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 41, // Original 41.5 but rounded down
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Glowstick",
+        "shortname": "Glowstick",
+        "hammerid": "257",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "258",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 25,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Flashlight",
+        "shortname": "Flashlight",
+        "hammerid": "248",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "default",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "246",
+                "event": "OnPlayerUse",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Barrel",
+        "shortname": "Barrel",
+        "hammerid": "364",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "grey",
+        "triggers": ["360"]
+    },
+    {
+        "name": "Zombie Slenderman",
+        "shortname": "ZM Slenderman",
+        "hammerid": "357",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "white",
+        "triggers": ["358"],
+        "handlers": [
+            {
+                "type": "game_ui",
+                "hammerid": "9853",
+                "event": "OnCase16",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_surf_danger_p.jsonc
+++ b/entwatch/ze_surf_danger_p.jsonc
@@ -1,0 +1,20 @@
+[
+    {
+        "name": "Cyka Blyat 1",
+        "shortname": "Cyka Blyat 1",
+        "hammerid": "2220",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red"
+    },
+    {
+        "name": "Cyka Blyat 2",
+        "shortname": "Cyka Blyat 2",
+        "hammerid": "2219",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red"
+    }
+]

--- a/entwatch/ze_surf_gypt_p.jsonc
+++ b/entwatch/ze_surf_gypt_p.jsonc
@@ -1,0 +1,38 @@
+[
+    {
+        "name": "Red Trail",
+        "shortname": "Red Trail",
+        "hammerid": "1293",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red"
+    },
+    {
+        "name": "Green Trail",
+        "shortname": "Green Trail",
+        "hammerid": "1295",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green"
+    },
+    {
+        "name": "Pompje's Pizza Boye",
+        "shortname": "Pizza",
+        "hammerid": "1289",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "yellow"
+    },
+    {
+        "name": "Blue Trail",
+        "shortname": "Blue Trail",
+        "hammerid": "1007",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue"
+    }
+]

--- a/entwatch/ze_surf_hp.jsonc
+++ b/entwatch/ze_surf_hp.jsonc
@@ -1,0 +1,63 @@
+[
+    {
+        "name": "Shotgun",
+        "shortname": "Shotgun",
+        "hammerid": "93",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "grey",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "91",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 45,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "God Heal",
+        "shortname": "God Heal",
+        "hammerid": "150",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "orange"
+    },
+    {
+        "name": "Once Heal",
+        "shortname": "Once Heal",
+        "hammerid": "66",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "olive"
+    },
+    {
+        "name": "Zombie Crossbow",
+        "shortname": "ZM Crossbow",
+        "hammerid": "102",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "darkred",
+        "triggers": ["121"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "100",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 30,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_surf_vortex_p.jsonc
+++ b/entwatch/ze_surf_vortex_p.jsonc
@@ -1,0 +1,23 @@
+[
+    {
+        "name": "Wall",
+        "shortname": "Wall",
+        "hammerid": "1798",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1799",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]


### PR DESCRIPTION
This PR adds entwatch configs for maps that tilgep missed. All files include item buttons/game_ui cooldowns despite not being implemented yet. Some configs have comments that denote some issues/questions I had when making the configs.

I recommend doing a full review, including syntax and modes. I tried my best to match existing CS:GO configs, although I did take the liberty of changing a few things (such as color, name/hud name, and modes). Some items may or may not have needed configs.

My next PR aims to add item cooldown tracking to the configs that tilgep made.

Configs to look out for:
- ze_grau_p: I wasn't sure how to implement the trigger ID system since it's a `trigger_geleport` that strips the knife, so I just added the same set of triggers to each item.
- ze_farmhouse_p: The map has a dynamic item use system that would benefit from having the `math_counter` detection implemented, but because of the lack of implementation, I've left them at one.