### PR TITLE
Fix item names

### DIFF
--- a/entwatch/ze_ffvii_temple_ancient.jsonc
+++ b/entwatch/ze_ffvii_temple_ancient.jsonc
@@ -21,13 +21,13 @@
         ]
     },
     {
-        "name": "Gravity",
-        "shortname": "Gravity",
+        "name": "Earth",
+        "shortname": "Earth",
         "hammerid": "1638",
         "message": true,
         "ui": true,
         "transfer": true,
-        "color": "purple",
+        "color": "orange",
         "handlers": [
             {
                 "type": "button",
@@ -105,13 +105,13 @@
         ]
     },
     {
-        "name": "Electro",
-        "shortname": "Electro",
+        "name": "Poison",
+        "shortname": "Poison",
         "hammerid": "1617",
         "message": true,
         "ui": true,
         "transfer": true,
-        "color": "blue",
+        "color": "green",
         "handlers": [
             {
                 "type": "button",

--- a/entwatch/ze_tesv_skyrim_p.jsonc
+++ b/entwatch/ze_tesv_skyrim_p.jsonc
@@ -118,8 +118,8 @@
         ]
     },
     {
-        "name": "Deadric",
-        "shortname": "Deadric",
+        "name": "Daedric",
+        "shortname": "Daedric",
         "hammerid": "29402",
         "message": true,
         "ui": true,
@@ -138,7 +138,7 @@
                 "ui": true
             },
             {
-                "type": "game_ui", // M1
+                "type": "game_ui", // M2
                 "hammerid": "29412",
                 "event": "OnTrigger",
                 "mode": 4,


### PR DESCRIPTION
This pull request fixes...
- misconfiguration of `Earth` and `Poison` item names/colors on temple ancient.
- mispelling of `daedric` on skyrim