### PR TITLE
Fix FFXII Westersand v8 Stripper

### DIFF
--- a/stripper/ze_ffxii_westersand_v8/default_ents.jsonc
+++ b/stripper/ze_ffxii_westersand_v8/default_ents.jsonc
@@ -101,7 +101,7 @@
 						"outputname": "OnMapSpawn",
 						"targetname": "Staff_*_Epicker",
 						"inputname": "Kill",
-						"delay": 10.0,
+						"delay": 15.0,
 						"timestofire": 1
 					}
 				]


### PR DESCRIPTION
Previously, the `delay` parameter for the kill input on the epick blockers were set too early, resulting in items spawning with the blockers after the input. This PR delays the output by another 5 seconds.