### PR TITLE
More Entwatch Configs

### DIFF
--- a/entwatch/ze_chicago_bean_gassy_fart_life.jsonc
+++ b/entwatch/ze_chicago_bean_gassy_fart_life.jsonc
@@ -1,0 +1,65 @@
+[
+    {
+        "name": "Holy Gas Grenade",
+        "shortname": "Holy",
+        "hammerid": "1539",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "game_ui",
+                "hammerid": "1546",
+                "event": "OnPass",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Chicago Light",
+        "shortname": "Light",
+        "hammerid": "2032",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "game_ui",
+                "hammerid": "2048",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Heal",
+        "shortname": "Heal",
+        "hammerid": "2055",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "game_ui",
+                "hammerid": "2064",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_dark_souls.jsonc
+++ b/entwatch/ze_dark_souls.jsonc
@@ -10,18 +10,18 @@
         "handlers": [
             {
                 "type": "button",
-                "hammerid": "",
+                "hammerid": "25950",
                 "event": "OnPressed",
-                "mode": 0,
-                "cooldown": 0,
+                "mode": 2,
+                "cooldown": 4.5,
                 "maxuses": 0,
                 "message": true,
                 "ui": true
             },
             {
                 "type": "counter",
-                "hammerid": "",
-                "mode": 0,
+                "hammerid": "25942",
+                "mode": 6,
                 "ui": true
             }
         ]
@@ -33,19 +33,7 @@
         "message": true,
         "ui": true,
         "transfer": true,
-        "color": "white",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "",
-                "event": "OnPressed",
-                "mode": 0,
-                "cooldown": 0,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
+        "color": "white"
     },
     {
         "name": "Zombie Black Flame",
@@ -55,22 +43,22 @@
         "ui": true,
         "transfer": false,
         "color": "purple",
-        "triggers": [""],
+        "triggers": ["25971"],
         "handlers": [
             {
                 "type": "button",
-                "hammerid": "",
+                "hammerid": "25992",
                 "event": "OnPressed",
-                "mode": 0,
-                "cooldown": 0,
+                "mode": 2,
+                "cooldown": 2.5,
                 "maxuses": 0,
                 "message": true,
                 "ui": true
             },
             {
                 "type": "counter",
-                "hammerid": "",
-                "mode": 0,
+                "hammerid": "25983",
+                "mode": 6,
                 "ui": true
             }
         ]
@@ -86,18 +74,18 @@
         "handlers": [
             {
                 "type": "button",
-                "hammerid": "",
+                "hammerid": "26039",
                 "event": "OnPressed",
-                "mode": 0,
-                "cooldown": 0,
+                "mode": 2,
+                "cooldown": 2.5,
                 "maxuses": 0,
                 "message": true,
                 "ui": true
             },
             {
                 "type": "counter",
-                "hammerid": "",
-                "mode": 0,
+                "hammerid": "26031",
+                "mode": 6,
                 "ui": true
             }
         ]
@@ -113,18 +101,18 @@
         "handlers": [
             {
                 "type": "button",
-                "hammerid": "",
+                "hammerid": "26245",
                 "event": "OnPressed",
-                "mode": 0,
-                "cooldown": 0,
+                "mode": 2,
+                "cooldown": 10,
                 "maxuses": 0,
                 "message": true,
                 "ui": true
             },
             {
                 "type": "counter",
-                "hammerid": "",
-                "mode": 0,
+                "hammerid": "26240",
+                "mode": 6,
                 "ui": true
             }
         ]
@@ -137,22 +125,22 @@
         "ui": true,
         "transfer": false,
         "color": "red",
-        "triggers": [""],
+        "triggers": ["25998"],
         "handlers": [
             {
                 "type": "button",
-                "hammerid": "",
+                "hammerid": "26009",
                 "event": "OnPressed",
-                "mode": 0,
-                "cooldown": 0,
+                "mode": 2,
+                "cooldown": 20,
                 "maxuses": 0,
                 "message": true,
                 "ui": true
             },
             {
                 "type": "counter",
-                "hammerid": "",
-                "mode": 0,
+                "hammerid": "26003",
+                "mode": 6,
                 "ui": true
             }
         ]
@@ -165,22 +153,22 @@
         "ui": true,
         "transfer": false,
         "color": "red",
-        "triggers": [""],
+        "triggers": ["26269"],
         "handlers": [
             {
                 "type": "button",
-                "hammerid": "",
+                "hammerid": "26280",
                 "event": "OnPressed",
-                "mode": 0,
-                "cooldown": 0,
+                "mode": 2,
+                "cooldown": 15,
                 "maxuses": 0,
                 "message": true,
                 "ui": true
             },
             {
                 "type": "counter",
-                "hammerid": "",
-                "mode": 0,
+                "hammerid": "26275",
+                "mode": 6,
                 "ui": true
             }
         ]
@@ -196,18 +184,18 @@
         "handlers": [
             {
                 "type": "button",
-                "hammerid": "",
+                "hammerid": "26223",
                 "event": "OnPressed",
-                "mode": 0,
-                "cooldown": 0,
+                "mode": 2,
+                "cooldown": 10,
                 "maxuses": 0,
                 "message": true,
                 "ui": true
             },
             {
                 "type": "counter",
-                "hammerid": "",
-                "mode": 0,
+                "hammerid": "26213",
+                "mode": 6,
                 "ui": true
             }
         ]
@@ -223,18 +211,18 @@
         "handlers": [
             {
                 "type": "button",
-                "hammerid": "",
+                "hammerid": "26128",
                 "event": "OnPressed",
-                "mode": 0,
-                "cooldown": 0,
+                "mode": 2,
+                "cooldown": 2.5,
                 "maxuses": 0,
                 "message": true,
                 "ui": true
             },
             {
                 "type": "counter",
-                "hammerid": "",
-                "mode": 0,
+                "hammerid": "26120",
+                "mode": 6,
                 "ui": true
             }
         ]
@@ -250,18 +238,18 @@
         "handlers": [
             {
                 "type": "button",
-                "hammerid": "",
+                "hammerid": "26263",
                 "event": "OnPressed",
-                "mode": 0,
-                "cooldown": 0,
+                "mode": 2,
+                "cooldown": 7.5,
                 "maxuses": 0,
                 "message": true,
                 "ui": true
             },
             {
                 "type": "counter",
-                "hammerid": "",
-                "mode": 0,
+                "hammerid": "26255",
+                "mode": 6,
                 "ui": true
             }
         ]
@@ -274,22 +262,22 @@
         "ui": true,
         "transfer": false,
         "color": "blue",
-        "triggers": [""],
+        "triggers": ["26285"],
         "handlers": [
             {
                 "type": "button",
-                "hammerid": "",
+                "hammerid": "26301",
                 "event": "OnPressed",
-                "mode": 0,
-                "cooldown": 0,
+                "mode": 2,
+                "cooldown": 8,
                 "maxuses": 0,
                 "message": true,
                 "ui": true
             },
             {
                 "type": "counter",
-                "hammerid": "",
-                "mode": 0,
+                "hammerid": "26293",
+                "mode": 6,
                 "ui": true
             }
         ]
@@ -305,18 +293,18 @@
         "handlers": [
             {
                 "type": "button",
-                "hammerid": "",
+                "hammerid": "26063",
                 "event": "OnPressed",
-                "mode": 0,
-                "cooldown": 0,
+                "mode": 2,
+                "cooldown": 2.5,
                 "maxuses": 0,
                 "message": true,
                 "ui": true
             },
             {
                 "type": "counter",
-                "hammerid": "",
-                "mode": 0,
+                "hammerid": "26055",
+                "mode": 6,
                 "ui": true
             }
         ]
@@ -332,18 +320,18 @@
         "handlers": [
             {
                 "type": "button",
-                "hammerid": "",
+                "hammerid": "26155",
                 "event": "OnPressed",
-                "mode": 0,
-                "cooldown": 0,
+                "mode": 2,
+                "cooldown": 7,
                 "maxuses": 0,
                 "message": true,
                 "ui": true
             },
             {
                 "type": "counter",
-                "hammerid": "",
-                "mode": 0,
+                "hammerid": "26143",
+                "mode": 6,
                 "ui": true
             }
         ]
@@ -361,16 +349,16 @@
                 "type": "button",
                 "hammerid": "25916",
                 "event": "OnPressed",
-                "mode": 0,
-                "cooldown": 0,
+                "mode": 2,
+                "cooldown": 7,
                 "maxuses": 0,
                 "message": true,
                 "ui": true
             },
             {
                 "type": "counter",
-                "hammerid": "",
-                "mode": 0,
+                "hammerid": "25908",
+                "mode": 6,
                 "ui": true
             }
         ]
@@ -386,18 +374,18 @@
         "handlers": [
             {
                 "type": "button",
-                "hammerid": "",
+                "hammerid": "25965",
                 "event": "OnPressed",
-                "mode": 0,
-                "cooldown": 0,
+                "mode": 2,
+                "cooldown": 7,
                 "maxuses": 0,
                 "message": true,
                 "ui": true
             },
             {
                 "type": "counter",
-                "hammerid": "",
-                "mode": 0,
+                "hammerid": "25960",
+                "mode": 6,
                 "ui": true
             }
         ]
@@ -410,22 +398,22 @@
         "ui": true,
         "transfer": false,
         "color": "yellow",
-        "triggers": [""],
+        "triggers": ["26079"],
         "handlers": [
             {
                 "type": "button",
-                "hammerid": "",
+                "hammerid": "26103",
                 "event": "OnPressed",
-                "mode": 0,
-                "cooldown": 0,
+                "mode": 2,
+                "cooldown": 2.5,
                 "maxuses": 0,
                 "message": true,
                 "ui": true
             },
             {
                 "type": "counter",
-                "hammerid": "",
-                "mode": 0,
+                "hammerid": "26090",
+                "mode": 6,
                 "ui": true
             }
         ]
@@ -441,18 +429,18 @@
         "handlers": [
             {
                 "type": "button",
-                "hammerid": "",
+                "hammerid": "26315",
                 "event": "OnPressed",
-                "mode": 0,
-                "cooldown": 0,
+                "mode": 2,
+                "cooldown": 10,
                 "maxuses": 0,
                 "message": true,
                 "ui": true
             },
             {
                 "type": "counter",
-                "hammerid": "",
-                "mode": 0,
+                "hammerid": "26308",
+                "mode": 6,
                 "ui": true
             }
         ]
@@ -468,18 +456,18 @@
         "handlers": [
             {
                 "type": "button",
-                "hammerid": "",
+                "hammerid": "26180",
                 "event": "OnPressed",
-                "mode": 0,
-                "cooldown": 0,
+                "mode": 2,
+                "cooldown": 2.5,
                 "maxuses": 0,
                 "message": true,
                 "ui": true
             },
             {
                 "type": "counter",
-                "hammerid": "",
-                "mode": 0,
+                "hammerid": "26172",
+                "mode": 6,
                 "ui": true
             }
         ]
@@ -495,18 +483,18 @@
         "handlers": [
             {
                 "type": "button",
-                "hammerid": "",
+                "hammerid": "26203",
                 "event": "OnPressed",
-                "mode": 0,
-                "cooldown": 0,
+                "mode": 2,
+                "cooldown": 1.5,
                 "maxuses": 0,
                 "message": true,
                 "ui": true
             },
             {
                 "type": "counter",
-                "hammerid": "",
-                "mode": 0,
+                "hammerid": "26196",
+                "mode": 6,
                 "ui": true
             }
         ]

--- a/entwatch/ze_dark_souls.jsonc
+++ b/entwatch/ze_dark_souls.jsonc
@@ -1,0 +1,514 @@
+[
+    {
+        "name": "Estus Flask",
+        "shortname": "Estus",
+        "hammerid": "25937",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "white",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "",
+                "event": "OnPressed",
+                "mode": 0,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "",
+                "mode": 0,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Skull Lantern",
+        "shortname": "Lantern",
+        "hammerid": "33527",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "white",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "",
+                "event": "OnPressed",
+                "mode": 0,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Black Flame",
+        "shortname": "ZM Flame",
+        "hammerid": "25970",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "purple",
+        "triggers": [""],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "",
+                "event": "OnPressed",
+                "mode": 0,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "",
+                "mode": 0,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Dark Orb",
+        "shortname": "Dark Orb",
+        "hammerid": "26020",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "purple",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "",
+                "event": "OnPressed",
+                "mode": 0,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "",
+                "mode": 0,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Dark Storm",
+        "shortname": "Dark Storm",
+        "hammerid": "26228",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "purple",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "",
+                "event": "OnPressed",
+                "mode": 0,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "",
+                "mode": 0,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Poison Mist",
+        "shortname": "ZM Poison",
+        "hammerid": "25997",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": [""],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "",
+                "event": "OnPressed",
+                "mode": 0,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "",
+                "mode": 0,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Toxic Mist",
+        "shortname": "ZM Mist",
+        "hammerid": "26268",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": [""],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "",
+                "event": "OnPressed",
+                "mode": 0,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "",
+                "mode": 0,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Chaos Storm",
+        "shortname": "Chaos Storm",
+        "hammerid": "26207",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "",
+                "event": "OnPressed",
+                "mode": 0,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "",
+                "mode": 0,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Fireball",
+        "shortname": "Fireball",
+        "hammerid": "26109",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "",
+                "event": "OnPressed",
+                "mode": 0,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "",
+                "mode": 0,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Hidden Body",
+        "shortname": "Hidden Body",
+        "hammerid": "26250",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "",
+                "event": "OnPressed",
+                "mode": 0,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "",
+                "mode": 0,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Power Within",
+        "shortname": "ZM Power Within",
+        "hammerid": "26284",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "blue",
+        "triggers": [""],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "",
+                "event": "OnPressed",
+                "mode": 0,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "",
+                "mode": 0,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Great Heavy Soul Arrow",
+        "shortname": "Soul Arrow",
+        "hammerid": "26044",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "",
+                "event": "OnPressed",
+                "mode": 0,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "",
+                "mode": 0,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "White Dragon Breath",
+        "shortname": "Dragon Breath",
+        "hammerid": "26133",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "",
+                "event": "OnPressed",
+                "mode": 0,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "",
+                "mode": 0,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Spook",
+        "shortname": "Spook",
+        "hammerid": "25904",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "25916",
+                "event": "OnPressed",
+                "mode": 0,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "",
+                "mode": 0,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Soothing Sunlight",
+        "shortname": "Sunlight",
+        "hammerid": "25954",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "yellow",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "",
+                "event": "OnPressed",
+                "mode": 0,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "",
+                "mode": 0,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Rapport",
+        "shortname": "ZM Rapport",
+        "hammerid": "26068",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "yellow",
+        "triggers": [""],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "",
+                "event": "OnPressed",
+                "mode": 0,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "",
+                "mode": 0,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Blessed Weapon",
+        "shortname": "Blessed Weapon",
+        "hammerid": "26306",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "yellow",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "",
+                "event": "OnPressed",
+                "mode": 0,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "",
+                "mode": 0,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Lightning Spear",
+        "shortname": "Lightning Spear",
+        "hammerid": "26161",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "yellow",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "",
+                "event": "OnPressed",
+                "mode": 0,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "",
+                "mode": 0,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Wrath of the Gods",
+        "shortname": "Wrath",
+        "hammerid": "26185",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "yellow",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "",
+                "event": "OnPressed",
+                "mode": 0,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "",
+                "mode": 0,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_farmhouse_p.jsonc
+++ b/entwatch/ze_farmhouse_p.jsonc
@@ -2,26 +2,26 @@
     {
         "name": "Zombie Tank",
         "shortname": "ZM Tank",
-        "hammerid": "28353",
+        "hammerid": "28409",
         "message": true,
         "ui": true,
         "transfer": false,
         "color": "darkred",
-        "triggers": ["28356"],
+        "triggers": ["28412"],
         "handlers": [
             {
                 "type": "button",
-                "hammerid": "28343",
+                "hammerid": "28399",
                 "event": "OnPressed",
                 "mode": 2,
                 "cooldown": 7,
                 "maxuses": 0,
-                "message": true,
+                "message": false,
                 "ui": true
             },
             {
                 "type": "game_ui",
-                "hammerid": "28351",
+                "hammerid": "28407",
                 "event": "OnTrigger",
                 "mode": 1,
                 "cooldown": 0,
@@ -31,7 +31,7 @@
             },
             {
                 "type": "game_ui",
-                "hammerid": "28334",
+                "hammerid": "28390",
                 "event": "OnTrigger",
                 "mode": 1,
                 "cooldown": 0,
@@ -81,8 +81,8 @@
                 "type": "button",
                 "hammerid": "6039",
                 "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 1,
+                "mode": 1,
+                "cooldown": 0,
                 "maxuses": 0,
                 "message": true,
                 "ui": true
@@ -108,8 +108,8 @@
                 "type": "button",
                 "hammerid": "5977",
                 "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 2,
+                "mode": 1,
+                "cooldown": 0,
                 "maxuses": 0,
                 "message": true,
                 "ui": true
@@ -125,7 +125,7 @@
     {
         "name": "Plasma Beam Cannon",
         "shortname": "Plasma",
-        "hammerid": "28388",
+        "hammerid": "28444",
         "message": true,
         "ui": true,
         "transfer": true,
@@ -133,7 +133,7 @@
         "handlers": [
             {
                 "type": "button",
-                "hammerid": "28396",
+                "hammerid": "28452",
                 "event": "OnPressed",
                 "mode": 1,
                 "cooldown": 0,

--- a/entwatch/ze_ffvii_cosmo_canyon_t.jsonc
+++ b/entwatch/ze_ffvii_cosmo_canyon_t.jsonc
@@ -1,0 +1,310 @@
+[
+    {
+        "name": "Phoenix Down",
+        "shortname": "Phoenix",
+        "hammerid": "3883",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3776",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Sleep Materia",
+        "shortname": "Sleep",
+        "hammerid": "7519",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "pink",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "20823",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Bio Materia",
+        "shortname": "Bio",
+        "hammerid": "4259",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "darkblue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "20819",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Ultima Materia",
+        "shortname": "Ultima",
+        "hammerid": "3464",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "20815",
+                "event": "OnPressed",
+                "mode": 4,
+                "cooldown": 15,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Electro Materia",
+        "shortname": "Electro",
+        "hammerid": "2418",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "20811",
+                "event": "OnPressed",
+                "mode": 5,
+                "cooldown": 60,
+                "maxuses": 2,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Earth Materia",
+        "shortname": "Earth",
+        "hammerid": "1878",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "orange",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "20809",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Wind Materia",
+        "shortname": "Wind",
+        "hammerid": "7475",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "20817",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Poison",
+        "shortname": "ZM Poison",
+        "hammerid": "7616",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "green",
+        "triggers": ["7617"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "7719",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Heal Materia",
+        "shortname": "Heal",
+        "hammerid": "1995",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "white",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "20807",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Gravity Materia",
+        "shortname": "Gravity",
+        "hammerid": "4775",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "purple",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "20821",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Confuse",
+        "shortname": "ZM Confuse",
+        "hammerid": "4394",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "purple",
+        "triggers": ["4400"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4229",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 75,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Ice",
+        "shortname": "ZM Ice",
+        "hammerid": "3332",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "blue",
+        "triggers": ["3333"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3339",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Fire",
+        "shortname": "ZM Fire",
+        "hammerid": "7571",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["7466"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3541",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Fire Materia",
+        "shortname": "Fire",
+        "hammerid": "2552",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "20813",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Cactus",
+        "shortname": "ZM Cactus",
+        "hammerid": "17789",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "green",
+        "triggers": ["2711"]
+    }
+]

--- a/entwatch/ze_ffvii_snow_cosmo.jsonc
+++ b/entwatch/ze_ffvii_snow_cosmo.jsonc
@@ -238,7 +238,7 @@
                 "event": "OnPressed",
                 "mode": 5,
                 "cooldown": 60,
-                "maxuses": 3,
+                "maxuses": 2,
                 "message": true,
                 "ui": true
             }

--- a/entwatch/ze_ffvii_snow_cosmo.jsonc
+++ b/entwatch/ze_ffvii_snow_cosmo.jsonc
@@ -22,7 +22,7 @@
         ]
     },
     {
-        "name": "Phoenix Down Potion",
+        "name": "Phoenix Down",
         "shortname": "Phoenix",
         "hammerid": "3972",
         "message": true,

--- a/entwatch/ze_ffvii_snow_cosmo.jsonc
+++ b/entwatch/ze_ffvii_snow_cosmo.jsonc
@@ -1,0 +1,396 @@
+[
+    {
+        "name": "Zombie Confuse",
+        "shortname": "ZM Confuse",
+        "hammerid": "4500",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "pink",
+        "triggers": ["4501"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4495",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 75,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Phoenix Down Potion",
+        "shortname": "Phoenix",
+        "hammerid": "3972",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3973",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Poison",
+        "shortname": "ZM Poison",
+        "hammerid": "3844",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "green",
+        "triggers": ["3845"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3848",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Fire",
+        "shortname": "ZM Fire",
+        "hammerid": "3843",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["3841"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3838",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Ice",
+        "shortname": "ZM Ice",
+        "hammerid": "3599",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "blue",
+        "triggers": ["3597"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3595",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Cactus",
+        "shortname": "ZM Cactus",
+        "hammerid": "3571",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "green",
+        "triggers": ["3568"]
+    },
+    {
+        "name": "Sleep Materia",
+        "shortname": "Sleep",
+        "hammerid": "2905",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "pink",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2907",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Heal Materia",
+        "shortname": "Heal",
+        "hammerid": "2644",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "white",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2647",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Wind Materia",
+        "shortname": "Wind",
+        "hammerid": "2692",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "agreen",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2693",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Gravity Materia",
+        "shortname": "Gravity",
+        "hammerid": "2685",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "purple",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2686",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Bio Materia",
+        "shortname": "Bio",
+        "hammerid": "2677",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "darkblue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2679",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Electro Materia",
+        "shortname": "Electro",
+        "hammerid": "2669",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "darkblue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2672",
+                "event": "OnPressed",
+                "mode": 5,
+                "cooldown": 60,
+                "maxuses": 3,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Fire Materia",
+        "shortname": "Fire",
+        "hammerid": "2650",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2651",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Earth Materia",
+        "shortname": "Earth",
+        "hammerid": "2707",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "orange",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2708",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Ultima Materia",
+        "shortname": "Ultima",
+        "hammerid": "2715",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2716",
+                "event": "OnPressed",
+                "mode": 4,
+                "cooldown": 1,
+                "maxuses": 15,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Gravity",
+        "shortname": "ZM Gravity",
+        "hammerid": "2106",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "purple",
+        "triggers": ["2013"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2107",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Invisibility",
+        "shortname": "ZM Invis",
+        "hammerid": "2095",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "olive",
+        "triggers": ["2093"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2097",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Ice Materia",
+        "shortname": "Ice",
+        "hammerid": "2041",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2036",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Damage Materia",
+        "shortname": "Damage",
+        "hammerid": "2021",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2022",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_ffxii_paramina_rift.jsonc
+++ b/entwatch/ze_ffxii_paramina_rift.jsonc
@@ -21,6 +21,111 @@
         ]
     },
     {
+        "name": "Wind Magick",
+        "shortname": "Wind",
+        "hammerid": "13023",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "15499",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Poison Magick",
+        "shortname": "Poison",
+        "hammerid": "13022",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "15497",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Ice Magick",
+        "shortname": "Ice",
+        "hammerid": "13021",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "15495",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Fire Magick",
+        "shortname": "Fire",
+        "hammerid": "13020",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "15493",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Heal Magick",
+        "shortname": "Heal",
+        "hammerid": "13019",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "white",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "15491",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
         "name": "Holy Potion",
         "shortname": "Holy",
         "hammerid": "13028",
@@ -163,111 +268,6 @@
                 "event": "OnPressed",
                 "mode": 2,
                 "cooldown": 65,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Wind Magick",
-        "shortname": "Wind",
-        "hammerid": "13023",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "green",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "15499",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 60,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Poison Magick",
-        "shortname": "Poison",
-        "hammerid": "13022",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "green",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "15497",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 60,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Ice Magick",
-        "shortname": "Ice",
-        "hammerid": "13021",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "blue",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "15495",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 60,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Fire Magick",
-        "shortname": "Fire",
-        "hammerid": "13020",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "red",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "15493",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 60,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Heal Magick",
-        "shortname": "Heal",
-        "hammerid": "13019",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "white",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "15491",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 60,
                 "maxuses": 0,
                 "message": true,
                 "ui": true

--- a/entwatch/ze_ffxiv_great_gubal_library.jsonc
+++ b/entwatch/ze_ffxiv_great_gubal_library.jsonc
@@ -1,0 +1,295 @@
+[
+    {
+        "name": "Zombie Silence",
+        "shortname": "ZM Silence",
+        "hammerid": "24970",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["24968"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "24965",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Shield",
+        "shortname": "ZM Shield",
+        "hammerid": "24952",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["24950"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "24947",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Heal",
+        "shortname": "ZM Heal",
+        "hammerid": "24910",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "triggers": ["24908"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "24914",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 65,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Gravity",
+        "shortname": "ZM Gravity",
+        "hammerid": "24853",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "purple",
+        "triggers": ["24851"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "24882",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Speed",
+        "shortname": "Speed",
+        "hammerid": "24713",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "grey",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "24709",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Bio Element",
+        "shortname": "Bio",
+        "hammerid": "24683",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "24679",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Electricity Element",
+        "shortname": "Electricity",
+        "hammerid": "24669",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "24670",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Fire Element",
+        "shortname": "Fire",
+        "hammerid": "24577",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "24580",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Sage",
+        "shortname": "Sage",
+        "hammerid": "15874",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "15869",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 20,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Blackhole",
+        "shortname": "Blackhole",
+        "hammerid": "15866",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "purple",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "15863",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Ice Element",
+        "shortname": "Ice",
+        "hammerid": "15839",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "15840",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 65,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Summoner",
+        "shortname": "Summoner",
+        "hammerid": "15788",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "15790",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 45,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Black Mage",
+        "shortname": "Black Mage",
+        "hammerid": "15754",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "15759",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 180,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "button",
+                "hammerid": "15755",
+                "event": "OnPressed",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "15763",
+                "mode": 6,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_misaka.jsonc
+++ b/entwatch/ze_misaka.jsonc
@@ -1,0 +1,66 @@
+[
+    {
+        "name": "Wind",
+        "shortname": "Wind",
+        "hammerid": "31104",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "31109",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Heal",
+        "shortname": "Heal",
+        "hammerid": "31069",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "white",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "31078",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Speed",
+        "shortname": "ZM Speed",
+        "hammerid": "31121",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["31119"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "31123",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 50,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_offliner.jsonc
+++ b/entwatch/ze_offliner.jsonc
@@ -1,0 +1,23 @@
+[
+    {
+        "name": "Shockwave",
+        "shortname": "Shockwave",
+        "hammerid": "3979",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3970",
+                "event": "OnPressed",
+                "mode": 4,
+                "cooldown": 15,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_overlord.jsonc
+++ b/entwatch/ze_overlord.jsonc
@@ -1,0 +1,608 @@
+[
+    {
+        "name": "King",
+        "shortname": "King",
+        "hammerid": "7255",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "yellow",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "7257",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 75,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Arrow",
+        "shortname": "Arrow",
+        "hammerid": "6521",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "grey",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "6522",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 10,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Small Heal",
+        "shortname": "S.Heal",
+        "hammerid": "6537",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red"
+    },
+    {
+        "name": "Wall",
+        "shortname": "Wall",
+        "hammerid": "6372",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "olive",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "6368",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 75,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Ultima",
+        "shortname": "Ultima",
+        "hammerid": "6599",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "pink",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "6595",
+                "event": "OnPressed",
+                "mode": 4,
+                "cooldown": 10,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Meteor",
+        "shortname": "Meteor",
+        "hammerid": "6585",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "6586",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 75,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Ice",
+        "shortname": "Ice",
+        "hammerid": "6579",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "6628",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Heal",
+        "shortname": "Heal",
+        "hammerid": "6636",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "heal",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "6637",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 75,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Scroll",
+        "shortname": "Scroll",
+        "hammerid": "6601",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "6602",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Sword",
+        "shortname": "Sword",
+        "hammerid": "6612",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "darkblue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "6613",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 75,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Wish",
+        "shortname": "Wish",
+        "hammerid": "6568",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "yellow",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "6570",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 150,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Poison",
+        "shortname": "Poison",
+        "hammerid": "6529",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "6527",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Electro",
+        "shortname": "Electro",
+        "hammerid": "6554",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "6556",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 15,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Fire",
+        "shortname": "Fire",
+        "hammerid": "6540",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "6541",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 15,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Ice",
+        "shortname": "ZM Ice",
+        "hammerid": "6506",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "blue",
+        "triggers": ["6504"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "6500",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Gravity",
+        "shortname": "ZM Gravity",
+        "hammerid": "6489",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "purple",
+        "triggers": ["6490"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "6493",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Warp",
+        "shortname": "ZM Warp",
+        "hammerid": "6474",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["6472"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "6476",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Speed",
+        "shortname": "ZM Speed",
+        "hammerid": "6357",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["6355"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "6358",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Invisibility",
+        "shortname": "ZM Invis",
+        "hammerid": "6348",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["6346"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "6342",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Blind",
+        "shortname": "ZM Blind",
+        "hammerid": "803",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["801"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "804",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 100,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Ainz Ooal Gown",
+        "shortname": "ZM Ainz",
+        "hammerid": "6420",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["6418"],
+        "handlers": [
+            {
+                "type": "game_ui",
+                "hammerid": "6422",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 8,
+                "maxuses": 0,
+                "message": false,
+                "ui": true
+            },
+            {
+                "type": "game_ui",
+                "hammerid": "6423",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 100,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Cocytus",
+        "shortname": "ZM Cocytus",
+        "hammerid": "6432",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["6430"],
+        "handlers": [
+            {
+                "type": "game_ui",
+                "hammerid": "6435",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 5,
+                "maxuses": 0,
+                "message": false,
+                "ui": true
+            },
+            {
+                "type": "game_ui",
+                "hammerid": "6434",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Death Knight",
+        "shortname": "ZM Knight",
+        "hammerid": "6443",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["6441"],
+        "handlers": [
+            {
+                "type": "game_ui",
+                "hammerid": "6446",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 5,
+                "maxuses": 0,
+                "message": false,
+                "ui": true
+            },
+            {
+                "type": "game_ui",
+                "hammerid": "6434",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 10,
+                "maxuses": 0,
+                "message": false,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Shalltear Bloodfallen",
+        "shortname": "ZM Shalltear",
+        "hammerid": "6459",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["6457"],
+        "handlers": [
+            {
+                "type": "game_ui",
+                "hammerid": "6454",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 5,
+                "maxuses": 0,
+                "message": false,
+                "ui": true
+            },
+            {
+                "type": "game_ui",
+                "hammerid": "6434",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 100,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Albedo",
+        "shortname": "ZM Albedo",
+        "hammerid": "6514",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["6512"],
+        "handlers": [
+            {
+                "type": "game_ui",
+                "hammerid": "6454",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 5,
+                "maxuses": 0,
+                "message": false,
+                "ui": true
+            },
+            {
+                "type": "game_ui",
+                "hammerid": "6434",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 100,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Platinum Dragon Lord Armor",
+        "shortname": "Platinum Armor",
+        "hammerid": "7537",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["7535"],
+        "handlers": [
+            {
+                "type": "game_ui",
+                "hammerid": "7530",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 3.5,
+                "maxuses": 0,
+                "message": false,
+                "ui": true
+            },
+            {
+                "type": "game_ui",
+                "hammerid": "7531",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 8,
+                "maxuses": 0,
+                "message": false,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_palace_adventure.jsonc
+++ b/entwatch/ze_palace_adventure.jsonc
@@ -1,0 +1,86 @@
+[
+    {
+        "name": "Water",
+        "shortname": "Water",
+        "hammerid": "971",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "darkblue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "972",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 55,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Wind",
+        "shortname": "Wind",
+        "hammerid": "939",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "934",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 55,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Heal",
+        "shortname": "Heal",
+        "hammerid": "918",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "white",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "914",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 40,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Fire",
+        "shortname": "Fire",
+        "hammerid": "864",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "865",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 50,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_palace_of_minolila_cs2.jsonc
+++ b/entwatch/ze_palace_of_minolila_cs2.jsonc
@@ -1,0 +1,225 @@
+[
+    {
+        "name": "Heal Magic",
+        "shortname": "Heal",
+        "hammerid": "328",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "white",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "329",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Snow Magic",
+        "shortname": "Snow",
+        "hammerid": "317",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "white",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "323",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 65,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Electro Magic",
+        "shortname": "Electro",
+        "hammerid": "307",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "yellow",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "312",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Wind Magic",
+        "shortname": "Wind",
+        "hammerid": "303",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "304",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 65,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Frostmourn",
+        "shortname": "Frostmourn",
+        "hammerid": "279",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "darkblue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "277",
+                "event": "OnPressed",
+                "mode": 4,
+                "cooldown": 15,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Earth Magic",
+        "shortname": "Earth",
+        "hammerid": "266",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "olive",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "269",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Gravity Magic",
+        "shortname": "Gravity",
+        "hammerid": "251",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "purple",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "252",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 65,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Gravity Magic",
+        "shortname": "ZM Gravity",
+        "hammerid": "248",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "purple",
+        "triggers": ["246"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "241",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 75,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Ice Magic",
+        "shortname": "ZM Ice",
+        "hammerid": "226",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "blue",
+        "triggers": ["224"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "220",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 55,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Heal Magic",
+        "shortname": "ZM Heal",
+        "hammerid": "216",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "white",
+        "triggers": ["214"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "210",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 50,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Touching Infection",
+        "shortname": "ZM Infect",
+        "hammerid": "194",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["192"]
+    }
+]

--- a/entwatch/ze_pirates_port_royal.jsonc
+++ b/entwatch/ze_pirates_port_royal.jsonc
@@ -1,0 +1,169 @@
+[
+    {
+        "name": "Heal",
+        "shortname": "Heal",
+        "hammerid": "9862",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "white",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "9864",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 56,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Bubbles",
+        "shortname": "Bubbles",
+        "hammerid": "9847",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "9849",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 56,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Barrel",
+        "shortname": "Barrel",
+        "hammerid": "9826",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "orange",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "9828",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 56,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Sword",
+        "shortname": "Sword",
+        "hammerid": "9815",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "darkblue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "9817",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 56,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Wall",
+        "shortname": "Wall",
+        "hammerid": "9806",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "9808",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 56,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Medallion",
+        "shortname": "Medallion",
+        "hammerid": "9669",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "yellow",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "9666",
+                "event": "OnPressed",
+                "mode": 4,
+                "cooldown": 15,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Last Medallion",
+        "shortname": "Last Medallion",
+        "hammerid": "10344",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "yellow"
+    },
+    {
+        "name": "Zombie Barbossa",
+        "shortname": "ZM Barbossa",
+        "hammerid": "10408",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "triggers": ["10412"],
+        "handlers": [
+            {
+                "type": "game_ui", // bomb
+                "hammerid": "10438",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 36,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "button", // sword
+                "hammerid": "2904",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 46,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_santassination_p.jsonc
+++ b/entwatch/ze_santassination_p.jsonc
@@ -108,7 +108,7 @@
         "name": "Speeder",
         "shortname": "Speeder",
         "hammerid": "547",
-        "message": true,
+        "message": false,
         "ui": false,
         "transfer": true,
         "color": "green",

--- a/entwatch/ze_scp_containment_breach.jsonc
+++ b/entwatch/ze_scp_containment_breach.jsonc
@@ -1,0 +1,110 @@
+[
+    {
+        "name": "SCP-714 - The Jaded Ring",
+        "shortname": "Ammo",
+        "hammerid": "5131",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5136",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 80,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "SCP-500 - Panacea",
+        "shortname": "Heal",
+        "hammerid": "5105",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5162",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "SCP-106 - The Old Man",
+        "shortname": "ZM Old Man",
+        "hammerid": "1436",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "grey",
+        "triggers": ["1434"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5288",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 30,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "SCP-049 - The Plague Doctor",
+        "shortname": "ZM Plague Doctor",
+        "hammerid": "1321",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "grey",
+        "triggers": ["1319"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5164",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "SCP-096 - The Shy Guy",
+        "shortname": "ZM Shy Guy",
+        "hammerid": "1329",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "grey",
+        "triggers": ["1327"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5166",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 100,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_scp_containment_breach.jsonc
+++ b/entwatch/ze_scp_containment_breach.jsonc
@@ -91,7 +91,7 @@
         "hammerid": "1329",
         "message": true,
         "ui": true,
-        "transfer": true,
+        "transfer": false,
         "color": "grey",
         "triggers": ["1327"],
         "handlers": [

--- a/entwatch/ze_scp_containment_breach.jsonc
+++ b/entwatch/ze_scp_containment_breach.jsonc
@@ -42,7 +42,7 @@
         ]
     },
     {
-        "name": "SCP-106 - The Old Man",
+        "name": "Zombie SCP-106 - The Old Man",
         "shortname": "ZM Old Man",
         "hammerid": "1436",
         "message": true,
@@ -64,7 +64,7 @@
         ]
     },
     {
-        "name": "SCP-049 - The Plague Doctor",
+        "name": "Zombie SCP-049 - The Plague Doctor",
         "shortname": "ZM Plague Doctor",
         "hammerid": "1321",
         "message": true,
@@ -86,7 +86,7 @@
         ]
     },
     {
-        "name": "SCP-096 - The Shy Guy",
+        "name": "Zombie SCP-096 - The Shy Guy",
         "shortname": "ZM Shy Guy",
         "hammerid": "1329",
         "message": true,

--- a/entwatch/ze_skygarden.jsonc
+++ b/entwatch/ze_skygarden.jsonc
@@ -1,0 +1,200 @@
+[
+    {
+        "name": "The Core",
+        "shortname": "Core",
+        "hammerid": "1278",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "grey"
+    },
+    {
+        "name": "Earth 2",
+        "shortname": "Earth 2",
+        "hammerid": "261",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "olive",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "262",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 50,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Earth 1",
+        "shortname": "Earth 1",
+        "hammerid": "706",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "olive",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "704",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 50,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Wind 1",
+        "shortname": "Wind 1",
+        "hammerid": "252",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "644",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 10,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Wind 2",
+        "shortname": "Wind 2",
+        "hammerid": "2129",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "627",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 10,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Fire",
+        "shortname": "Fire",
+        "hammerid": "1574",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "845",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 40,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Speed",
+        "shortname": "ZM Speed",
+        "hammerid": "696",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "white",
+        "triggers": ["1403"]
+    },
+    {
+        "name": "Zombie Wind",
+        "shortname": "ZM Wind",
+        "hammerid": "1567",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "green",
+        "triggers": ["1578"]
+    },
+    {
+        "name": "Wind 3",
+        "shortname": "Wind 3",
+        "hammerid": "697",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1776",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 10,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Wind Shield",
+        "shortname": "ZM Shield",
+        "hammerid": "1100",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "lightgreen",
+        "triggers": ["1097"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "",
+                "event": "OnPressed",
+                "mode": 0,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Ammo",
+        "shortname": "Ammo",
+        "hammerid": "2512",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "olive",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2496",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 40,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_toy_world_final.jsonc
+++ b/entwatch/ze_toy_world_final.jsonc
@@ -1,0 +1,44 @@
+[
+    {
+        "name": "Mouse Trap",
+        "shortname": "Trap",
+        "hammerid": "684",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "olive",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1159",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 42,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Water Gun",
+        "shortname": "Water",
+        "hammerid": "1040",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1134",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]

--- a/entwatch/ze_xenovation.jsonc
+++ b/entwatch/ze_xenovation.jsonc
@@ -1,0 +1,195 @@
+[
+    {
+        "name": "Green Cannon",
+        "shortname": "Green",
+        "hammerid": "4967",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4964",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 20,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Blue Cannon",
+        "shortname": "Blue",
+        "hammerid": "4846",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4847",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Xoly",
+        "shortname": "Xoly",
+        "hammerid": "4749",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "pink",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4742",
+                "event": "OnPressed",
+                "mode": 4,
+                "cooldown": 20,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Yellow Cannon",
+        "shortname": "Yellow",
+        "hammerid": "4494",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "yellow",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4495",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 30,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Purple Plazma",
+        "shortname": "Plazma",
+        "hammerid": "4461",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "purple",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4462",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 120,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Cannon 1",
+        "shortname": "ZM Cannon 1",
+        "hammerid": "2922",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["8650"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2904",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 40,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Cannon 2",
+        "shortname": "ZM Cannon 2",
+        "hammerid": "2837",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["8652"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2838",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 40,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Cannon 3",
+        "shortname": "ZM Cannon 3",
+        "hammerid": "2780",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["2782"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2749",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 40,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Speed",
+        "shortname": "ZM Speed",
+        "hammerid": "2686",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["8654"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2681",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    }
+]


### PR DESCRIPTION
Some key changes made in this pull request:
- Re-ordered items in FFXII Paramina Rift config based on what tilgep said about how items are displayed in the order they're set in the config
- Disabled speeder messages showing up in chat on Santassination
- Fixed Farmhouse items not displaying due to incorrect HammerIDs