### PR TITLE
Reorder Entwatch Configs

### DIFF
--- a/entwatch/ze_aooka3.jsonc
+++ b/entwatch/ze_aooka3.jsonc
@@ -1,221 +1,5 @@
 [
     {
-        "name": "Kohh",
-        "shortname": "Kohh",
-        "hammerid": "3155",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "purple",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "3151",
-                "event": "OnPressed",
-                "mode": 3,
-                "cooldown": 0,
-                "maxuses": 1,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Shackles Magick",
-        "shortname": "ZM Shackle",
-        "hammerid": "4948",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "purple",
-        "triggers": ["4949"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "4945",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 55,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Lure Magick",
-        "shortname": "ZM Lure",
-        "hammerid": "4988",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "purple",
-        "triggers": ["4986"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "4981",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 60,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Shield Magick",
-        "shortname": "ZM Shield",
-        "hammerid": "5001",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "yellow",
-        "triggers": ["4997"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "4994",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 65,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Rise Magick",
-        "shortname": "ZM Rise",
-        "hammerid": "5011",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "red",
-        "triggers": ["5009"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "5006",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 65,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie IceFire Magick",
-        "shortname": "ZM IceFire",
-        "hammerid": "5023",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "blue",
-        "triggers": ["5021"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "5015",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 60,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie End Magick",
-        "shortname": "ZM End",
-        "hammerid": "5036",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "red",
-        "triggers": ["5034"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "5028",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 60,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Water Magick",
-        "shortname": "Water",
-        "hammerid": "5069",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "darkblue",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "5064",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 65,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Wind Magick",
-        "shortname": "Wind",
-        "hammerid": "5128",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "green",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "5125",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 65,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Present Magick",
-        "shortname": "Present",
-        "hammerid": "11360",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "green",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "11371",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 60,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Electric Magick",
         "shortname": "Electric",
         "hammerid": "5150",
@@ -230,27 +14,6 @@
                 "event": "OnPressed",
                 "mode": 2,
                 "cooldown": 15,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Ice Magick",
-        "shortname": "Ice",
-        "hammerid": "5161",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "blue",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "5156",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 65,
                 "maxuses": 0,
                 "message": true,
                 "ui": true
@@ -314,6 +77,243 @@
                 "event": "OnPressed",
                 "mode": 2,
                 "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Ice Magick",
+        "shortname": "Ice",
+        "hammerid": "5161",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5156",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 65,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Kohh",
+        "shortname": "Kohh",
+        "hammerid": "3155",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "purple",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3151",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Present Magick",
+        "shortname": "Present",
+        "hammerid": "11360",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "11371",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Water Magick",
+        "shortname": "Water",
+        "hammerid": "5069",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "darkblue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5064",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 65,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Wind Magick",
+        "shortname": "Wind",
+        "hammerid": "5128",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5125",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 65,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie End Magick",
+        "shortname": "ZM End",
+        "hammerid": "5036",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["5034"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5028",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie IceFire Magick",
+        "shortname": "ZM IceFire",
+        "hammerid": "5023",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "blue",
+        "triggers": ["5021"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5015",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Lure Magick",
+        "shortname": "ZM Lure",
+        "hammerid": "4988",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "purple",
+        "triggers": ["4986"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4981",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Rise Magick",
+        "shortname": "ZM Rise",
+        "hammerid": "5011",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["5009"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5006",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 65,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Shackles Magick",
+        "shortname": "ZM Shackle",
+        "hammerid": "4948",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "purple",
+        "triggers": ["4949"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4945",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 55,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Shield Magick",
+        "shortname": "ZM Shield",
+        "hammerid": "5001",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "yellow",
+        "triggers": ["4997"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4994",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 65,
                 "maxuses": 0,
                 "message": true,
                 "ui": true

--- a/entwatch/ze_arcana_heart.jsonc
+++ b/entwatch/ze_arcana_heart.jsonc
@@ -21,6 +21,69 @@
         ]
     },
     {
+        "name": "Heal",
+        "shortname": "Heal",
+        "hammerid": "3169",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2857",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 80,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Push",
+        "shortname": "Push",
+        "hammerid": "4310",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2511",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 50,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Shield",
+        "shortname": "Shield",
+        "hammerid": "3792",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2690",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 80,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
         "name": "Zombie Cube",
         "shortname": "ZM Cube",
         "hammerid": "2941",
@@ -43,49 +106,6 @@
         ]
     },
     {
-        "name": "Heal",
-        "shortname": "Heal",
-        "hammerid": "3169",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "red",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "2857",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 80,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Water",
-        "shortname": "ZM Water",
-        "hammerid": "2958",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "darkblue",
-        "triggers": ["2735"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "2728",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 70,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Zombie Heal",
         "shortname": "ZM Heal",
         "hammerid": "4570",
@@ -98,27 +118,6 @@
             {
                 "type": "button",
                 "hammerid": "4356",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 50,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Push",
-        "shortname": "Push",
-        "hammerid": "4310",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "green",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "2511",
                 "event": "OnPressed",
                 "mode": 2,
                 "cooldown": 50,
@@ -151,20 +150,21 @@
         ]
     },
     {
-        "name": "Shield",
-        "shortname": "Shield",
-        "hammerid": "3792",
+        "name": "Zombie Water",
+        "shortname": "ZM Water",
+        "hammerid": "2958",
         "message": true,
         "ui": true,
-        "transfer": true,
-        "color": "blue",
+        "transfer": false,
+        "color": "darkblue",
+        "triggers": ["2735"],
         "handlers": [
             {
                 "type": "button",
-                "hammerid": "2690",
+                "hammerid": "2728",
                 "event": "OnPressed",
                 "mode": 2,
-                "cooldown": 80,
+                "cooldown": 70,
                 "maxuses": 0,
                 "message": true,
                 "ui": true

--- a/entwatch/ze_christmas_infection_p.jsonc
+++ b/entwatch/ze_christmas_infection_p.jsonc
@@ -1,49 +1,5 @@
 [
     {
-        "name": "Zombie Trampoline",
-        "shortname": "ZM Trampoline",
-        "hammerid": "4695",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "grey",
-        "triggers": ["4702"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "4697",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 76,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Heal",
-        "shortname": "ZM Heal",
-        "hammerid": "4670",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "white",
-        "triggers": ["4682"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "4672",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 56,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Napalm Candle",
         "shortname": "Napalm",
         "hammerid": "4642",
@@ -92,28 +48,6 @@
         ]
     },
     {
-        "name": "Zombie Ice Boomerang",
-        "shortname": "ZM Boomerang",
-        "hammerid": "4592",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "blue",
-        "triggers": ["4684"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "4622",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 35,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Icewall Spawner",
         "shortname": "Icewall",
         "hammerid": "4587",
@@ -150,6 +84,111 @@
                 "mode": 3,
                 "cooldown": 0,
                 "maxuses": 6,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Snowball Launcher",
+        "shortname": "Snowball",
+        "hammerid": "4502",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "white",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4513",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 35,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Magical Lantern",
+        "shortname": "Lantern",
+        "hammerid": "4480",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "yellow",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4494",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 61,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "The Core",
+        "shortname": "Core",
+        "hammerid": "1032",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "yellow"
+    },
+    {
+        "name": "Zombie Christmas Ogre",
+        "shortname": "ZM Ogre",
+        "hammerid": "4460",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["4463"]
+    },
+    {
+        "name": "Zombie Trampoline",
+        "shortname": "ZM Trampoline",
+        "hammerid": "4695",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "grey",
+        "triggers": ["4702"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4697",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 76,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Heal",
+        "shortname": "ZM Heal",
+        "hammerid": "4670",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "white",
+        "triggers": ["4682"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4672",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 56,
+                "maxuses": 0,
                 "message": true,
                 "ui": true
             }
@@ -200,17 +239,18 @@
         ]
     },
     {
-        "name": "Snowball Launcher",
-        "shortname": "Snowball",
-        "hammerid": "4502",
+        "name": "Zombie Ice Boomerang",
+        "shortname": "ZM Boomerang",
+        "hammerid": "4592",
         "message": true,
         "ui": true,
-        "transfer": true,
-        "color": "white",
+        "transfer": false,
+        "color": "blue",
+        "triggers": ["4684"],
         "handlers": [
             {
                 "type": "button",
-                "hammerid": "4513",
+                "hammerid": "4622",
                 "event": "OnPressed",
                 "mode": 2,
                 "cooldown": 35,
@@ -221,44 +261,14 @@
         ]
     },
     {
-        "name": "Magical Lantern",
-        "shortname": "Lantern",
-        "hammerid": "4480",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "yellow",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "4494",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 61,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Christmas Ogre",
-        "shortname": "ZM Ogre",
-        "hammerid": "4460",
+        "name": "Zombie King",
+        "shortname": "ZM King",
+        "hammerid": "1271",
         "message": true,
         "ui": true,
         "transfer": false,
-        "color": "red",
-        "triggers": ["4463"]
-    },
-    {
-        "name": "The Core",
-        "shortname": "Core",
-        "hammerid": "1032",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "yellow"
+        "color": "yellow",
+        "triggers": ["1269"]
     },
     {
         "name": "Hat",
@@ -286,15 +296,5 @@
         "ui": true,
         "transfer": true,
         "color": "yellow"
-    },
-    {
-        "name": "Zombie King",
-        "shortname": "ZM King",
-        "hammerid": "1271",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "yellow",
-        "triggers": ["1269"]
     }
 ]

--- a/entwatch/ze_cyberspace_v2.jsonc
+++ b/entwatch/ze_cyberspace_v2.jsonc
@@ -21,6 +21,48 @@
         ]
     },
     {
+        "name": "Subtract",
+        "shortname": "Subtract",
+        "hammerid": "2301",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2421",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 65,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Divide",
+        "shortname": "Divide",
+        "hammerid": "2224",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2222",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 45,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
         "name": "Zombie Multiply",
         "shortname": "ZM Multiply",
         "hammerid": "2274",
@@ -58,48 +100,6 @@
                 "event": "OnPressed",
                 "mode": 2,
                 "cooldown": 60,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Subtract",
-        "shortname": "Subtract",
-        "hammerid": "2301",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "blue",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "2421",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 65,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Divide",
-        "shortname": "Divide",
-        "hammerid": "2224",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "blue",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "2222",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 45,
                 "maxuses": 0,
                 "message": true,
                 "ui": true

--- a/entwatch/ze_dark_souls.jsonc
+++ b/entwatch/ze_dark_souls.jsonc
@@ -27,43 +27,6 @@
         ]
     },
     {
-        "name": "Skull Lantern",
-        "shortname": "Lantern",
-        "hammerid": "33527",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "white"
-    },
-    {
-        "name": "Zombie Black Flame",
-        "shortname": "ZM Flame",
-        "hammerid": "25970",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "purple",
-        "triggers": ["25971"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "25992",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 2.5,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            },
-            {
-                "type": "counter",
-                "hammerid": "25983",
-                "mode": 6,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Dark Orb",
         "shortname": "Dark Orb",
         "hammerid": "26020",
@@ -112,62 +75,6 @@
             {
                 "type": "counter",
                 "hammerid": "26240",
-                "mode": 6,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Poison Mist",
-        "shortname": "ZM Poison",
-        "hammerid": "25997",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "red",
-        "triggers": ["25998"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "26009",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 20,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            },
-            {
-                "type": "counter",
-                "hammerid": "26003",
-                "mode": 6,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Toxic Mist",
-        "shortname": "ZM Mist",
-        "hammerid": "26268",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "red",
-        "triggers": ["26269"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "26280",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 15,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            },
-            {
-                "type": "counter",
-                "hammerid": "26275",
                 "mode": 6,
                 "ui": true
             }
@@ -249,34 +156,6 @@
             {
                 "type": "counter",
                 "hammerid": "26255",
-                "mode": 6,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Power Within",
-        "shortname": "ZM Power Within",
-        "hammerid": "26284",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "blue",
-        "triggers": ["26285"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "26301",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 8,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            },
-            {
-                "type": "counter",
-                "hammerid": "26293",
                 "mode": 6,
                 "ui": true
             }
@@ -391,34 +270,6 @@
         ]
     },
     {
-        "name": "Zombie Rapport",
-        "shortname": "ZM Rapport",
-        "hammerid": "26068",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "yellow",
-        "triggers": ["26079"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "26103",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 2.5,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            },
-            {
-                "type": "counter",
-                "hammerid": "26090",
-                "mode": 6,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Blessed Weapon",
         "shortname": "Blessed Weapon",
         "hammerid": "26306",
@@ -494,6 +345,155 @@
             {
                 "type": "counter",
                 "hammerid": "26196",
+                "mode": 6,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Skull Lantern",
+        "shortname": "Lantern",
+        "hammerid": "33527",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "white"
+    },
+    {
+        "name": "Zombie Black Flame",
+        "shortname": "ZM Flame",
+        "hammerid": "25970",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "purple",
+        "triggers": ["25971"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "25992",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 2.5,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "25983",
+                "mode": 6,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Rapport",
+        "shortname": "ZM Rapport",
+        "hammerid": "26068",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "yellow",
+        "triggers": ["26079"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "26103",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 2.5,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "26090",
+                "mode": 6,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Power Within",
+        "shortname": "ZM Power Within",
+        "hammerid": "26284",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "blue",
+        "triggers": ["26285"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "26301",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 8,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "26293",
+                "mode": 6,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Poison Mist",
+        "shortname": "ZM Poison",
+        "hammerid": "25997",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["25998"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "26009",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 20,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "26003",
+                "mode": 6,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Toxic Mist",
+        "shortname": "ZM Mist",
+        "hammerid": "26268",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["26269"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "26280",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 15,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "26275",
                 "mode": 6,
                 "ui": true
             }

--- a/entwatch/ze_desperate_soul.jsonc
+++ b/entwatch/ze_desperate_soul.jsonc
@@ -1,5 +1,25 @@
 [
     {
+        "name": "Darkness",
+        "shortname": "Darkness",
+        "hammerid": "5443",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "purple",
+        "triggers": ["5444"]
+    },
+    {
+        "name": "Brightness",
+        "shortname": "Brightness",
+        "hammerid": "5439",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "white",
+        "triggers": ["5440"]
+    },
+    {
         "name": "Earthly Star",
         "shortname": "Star",
         "hammerid": "7189",
@@ -19,26 +39,6 @@
                 "ui": true
             }
         ]
-    },
-    {
-        "name": "Darkness",
-        "shortname": "Darkness",
-        "hammerid": "5443",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "purple",
-        "triggers": ["5444"]
-    },
-    {
-        "name": "Brightness",
-        "shortname": "Brightness",
-        "hammerid": "5439",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "white",
-        "triggers": ["5440"]
     },
     {
         "name": "Asylum",
@@ -62,28 +62,6 @@
         ]
     },
     {
-        "name": "Zombie Rescue",
-        "shortname": "ZM Rescue",
-        "hammerid": "5866",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "yellow",
-        "triggers": ["5861"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "5867",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 60,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Holy",
         "shortname": "Holy",
         "hammerid": "6006",
@@ -98,49 +76,6 @@
                 "event": "OnPressed",
                 "mode": 2,
                 "cooldown": 20,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Ichika",
-        "shortname": "Ichika",
-        "hammerid": "5003",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "grey",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "5004",
-                "event": "OnPressed",
-                "mode": 4,
-                "cooldown": 5,
-                "maxuses": 10,
-                "message": false,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Heal",
-        "shortname": "ZM Heal",
-        "hammerid": "3511",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "white",
-        "triggers": ["3512"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "3516",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 40,
                 "maxuses": 0,
                 "message": true,
                 "ui": true
@@ -232,28 +167,6 @@
         ]
     },
     {
-        "name": "Zombie Water",
-        "shortname": "ZM Water",
-        "hammerid": "6327",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "blue",
-        "triggers": ["6442"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "2751",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 60,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Dawn",
         "shortname": "Dawn",
         "hammerid": "2615",
@@ -289,6 +202,93 @@
                 "event": "OnPressed",
                 "mode": 2,
                 "cooldown": 30,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Ichika",
+        "shortname": "Ichika",
+        "hammerid": "5003",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "grey",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5004",
+                "event": "OnPressed",
+                "mode": 4,
+                "cooldown": 5,
+                "maxuses": 10,
+                "message": false,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Rescue",
+        "shortname": "ZM Rescue",
+        "hammerid": "5866",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "yellow",
+        "triggers": ["5861"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5867",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Heal",
+        "shortname": "ZM Heal",
+        "hammerid": "3511",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "white",
+        "triggers": ["3512"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3516",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 40,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Water",
+        "shortname": "ZM Water",
+        "hammerid": "6327",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "blue",
+        "triggers": ["6442"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2751",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
                 "maxuses": 0,
                 "message": true,
                 "ui": true

--- a/entwatch/ze_eternal_journey.jsonc
+++ b/entwatch/ze_eternal_journey.jsonc
@@ -1,49 +1,5 @@
 [
     {
-        "name": "Zombie Glasgavelen",
-        "shortname": "ZM Glasgavelen",
-        "hammerid": "3693",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "red",
-        "triggers": ["3691"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "5396",
-                "event": "OnPlayerUse",
-                "mode": 2,
-                "cooldown": 40,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Cromcruach",
-        "shortname": "ZM Cromcruach",
-        "hammerid": "3723",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "red",
-        "triggers": ["3750"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "5412",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 50,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Fire Staff",
         "shortname": "Fire",
         "hammerid": "2246",
@@ -149,6 +105,27 @@
         ]
     },
     {
+        "name": "Ultimate Staff",
+        "shortname": "Ultimate",
+        "hammerid": "3984",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3978",
+                "event": "OnPressed",
+                "mode": 4,
+                "cooldown": 15,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
         "name": "Zombie Fire",
         "shortname": "ZM Fire",
         "hammerid": "3641",
@@ -215,21 +192,44 @@
         ]
     },
     {
-        "name": "Ultimate Staff",
-        "shortname": "Ultimate",
-        "hammerid": "3984",
+        "name": "Zombie Glasgavelen",
+        "shortname": "ZM Glasgavelen",
+        "hammerid": "3693",
         "message": true,
         "ui": true,
-        "transfer": true,
-        "color": "green",
+        "transfer": false,
+        "color": "red",
+        "triggers": ["3691"],
         "handlers": [
             {
                 "type": "button",
-                "hammerid": "3978",
+                "hammerid": "5396",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 40,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Cromcruach",
+        "shortname": "ZM Cromcruach",
+        "hammerid": "3723",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["3750"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5412",
                 "event": "OnPressed",
-                "mode": 4,
-                "cooldown": 15,
-                "maxuses": 1,
+                "mode": 2,
+                "cooldown": 50,
+                "maxuses": 0,
                 "message": true,
                 "ui": true
             }

--- a/entwatch/ze_ffxii_mt_bur_omisace_v6.jsonc
+++ b/entwatch/ze_ffxii_mt_bur_omisace_v6.jsonc
@@ -84,27 +84,6 @@
         ]
     },
     {
-        "name": "Limit Break Magick",
-        "shortname": "Limit Break",
-        "hammerid": "2613",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "olive",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "3065",
-                "event": "OnPressed",
-                "mode": 3,
-                "cooldown": 0,
-                "maxuses": 1,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Poison Magick",
         "shortname": "Poison",
         "hammerid": "5397",
@@ -183,6 +162,27 @@
                 "mode": 2,
                 "cooldown": 75,
                 "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Limit Break Magick",
+        "shortname": "Limit Break",
+        "hammerid": "2613",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "olive",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3065",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
                 "message": true,
                 "ui": true
             }
@@ -316,7 +316,7 @@
     },
     {
         "name": "Loxley Bow",
-        "shortname": "Bow",
+        "shortname": "Loxley",
         "hammerid": "5066",
         "message": true,
         "ui": true,

--- a/entwatch/ze_ffxii_westersand_v8.jsonc
+++ b/entwatch/ze_ffxii_westersand_v8.jsonc
@@ -63,28 +63,6 @@
         ]
     },
     {
-        "name": "Holy Magick",
-        "shortname": "Holy",
-        "hammerid": "2950",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "white",
-        "triggers": [""],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "2943",
-                "event": "OnPressed",
-                "mode": 4,
-                "cooldown": 20,
-                "maxuses": 1,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Fire Magick",
         "shortname": "Fire",
         "hammerid": "2936",
@@ -142,6 +120,28 @@
                 "mode": 2,
                 "cooldown": 65,
                 "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Holy Magick",
+        "shortname": "Holy",
+        "hammerid": "2950",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "white",
+        "triggers": [""],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2943",
+                "event": "OnPressed",
+                "mode": 4,
+                "cooldown": 20,
+                "maxuses": 1,
                 "message": true,
                 "ui": true
             }

--- a/entwatch/ze_ffxii_westersand_v8.jsonc
+++ b/entwatch/ze_ffxii_westersand_v8.jsonc
@@ -1,5 +1,153 @@
 [
     {
+        "name": "Wind Magick",
+        "shortname": "Wind",
+        "hammerid": "2976",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2973",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 65,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Heal Magick",
+        "shortname": "Heal",
+        "hammerid": "2955",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "white",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2956",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Earth Magick",
+        "shortname": "Earth",
+        "hammerid": "2961",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "orange",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2930",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Holy Magick",
+        "shortname": "Holy",
+        "hammerid": "2950",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "white",
+        "triggers": [""],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2943",
+                "event": "OnPressed",
+                "mode": 4,
+                "cooldown": 20,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Fire Magick",
+        "shortname": "Fire",
+        "hammerid": "2936",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2941",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 65,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Electro Magick",
+        "shortname": "Electro",
+        "hammerid": "2966",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "yellow",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2970",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 65,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Water Magick",
+        "shortname": "Water",
+        "hammerid": "2928",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "darkblue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2923",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 65,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
         "name": "Solo Winner",
         "shortname": "Solo Winner",
         "hammerid": "3624",
@@ -191,154 +339,6 @@
                 "event": "OnPressed",
                 "mode": 2,
                 "cooldown": 80,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Wind Magick",
-        "shortname": "Wind",
-        "hammerid": "2976",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "green",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "2973",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 65,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Heal Magick",
-        "shortname": "Heal",
-        "hammerid": "2955",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "white",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "2956",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 60,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Earth Magick",
-        "shortname": "Earth",
-        "hammerid": "2961",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "orange",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "2930",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 60,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Holy Magick",
-        "shortname": "Holy",
-        "hammerid": "2950",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "white",
-        "triggers": [""],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "2943",
-                "event": "OnPressed",
-                "mode": 4,
-                "cooldown": 20,
-                "maxuses": 1,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Fire Magick",
-        "shortname": "Fire",
-        "hammerid": "2936",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "red",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "2941",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 65,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Electro Magick",
-        "shortname": "Electro",
-        "hammerid": "2966",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "yellow",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "2970",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 65,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Water Magick",
-        "shortname": "Water",
-        "hammerid": "2928",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "darkblue",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "2923",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 65,
                 "maxuses": 0,
                 "message": true,
                 "ui": true

--- a/entwatch/ze_ffxiv_great_gubal_library.jsonc
+++ b/entwatch/ze_ffxiv_great_gubal_library.jsonc
@@ -1,114 +1,5 @@
 [
     {
-        "name": "Zombie Silence",
-        "shortname": "ZM Silence",
-        "hammerid": "24970",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "red",
-        "triggers": ["24968"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "24965",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 70,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Shield",
-        "shortname": "ZM Shield",
-        "hammerid": "24952",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "red",
-        "triggers": ["24950"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "24947",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 70,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Heal",
-        "shortname": "ZM Heal",
-        "hammerid": "24910",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "red",
-        "triggers": ["24908"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "24914",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 65,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Gravity",
-        "shortname": "ZM Gravity",
-        "hammerid": "24853",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "purple",
-        "triggers": ["24851"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "24882",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 70,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Speed",
-        "shortname": "Speed",
-        "hammerid": "24713",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "grey",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "24709",
-                "event": "OnPressed",
-                "mode": 3,
-                "cooldown": 0,
-                "maxuses": 1,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Bio Element",
         "shortname": "Bio",
         "hammerid": "24683",
@@ -166,27 +57,6 @@
                 "mode": 3,
                 "cooldown": 0,
                 "maxuses": 1,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Sage",
-        "shortname": "Sage",
-        "hammerid": "15874",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "red",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "15869",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 20,
-                "maxuses": 0,
                 "message": true,
                 "ui": true
             }
@@ -288,6 +158,136 @@
                 "type": "counter",
                 "hammerid": "15763",
                 "mode": 6,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Sage",
+        "shortname": "Sage",
+        "hammerid": "15874",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "15869",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 20,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Speed",
+        "shortname": "Speed",
+        "hammerid": "24713",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "grey",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "24709",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Silence",
+        "shortname": "ZM Silence",
+        "hammerid": "24970",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["24968"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "24965",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Shield",
+        "shortname": "ZM Shield",
+        "hammerid": "24952",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["24950"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "24947",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Heal",
+        "shortname": "ZM Heal",
+        "hammerid": "24910",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "triggers": ["24908"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "24914",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 65,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Gravity",
+        "shortname": "ZM Gravity",
+        "hammerid": "24853",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "purple",
+        "triggers": ["24851"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "24882",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
                 "ui": true
             }
         ]

--- a/entwatch/ze_forsaken_temple.jsonc
+++ b/entwatch/ze_forsaken_temple.jsonc
@@ -147,6 +147,84 @@
         ]
     },
     {
+        "name": "Holy Magic",
+        "shortname": "Holy",
+        "hammerid": "1669",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "pink",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1665",
+                "event": "OnPressed",
+                "mode": 4,
+                "cooldown": 1,
+                "maxuses": 15,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Ammo Magic",
+        "shortname": "Ammo",
+        "hammerid": "1627",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "gold",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1623",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 90,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Fruit of Knowledge",
+        "shortname": "Fruit",
+        "hammerid": "3035",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "purple"
+    },
+    {
+        "name": "Flame of Magic",
+        "shortname": "Flame",
+        "hammerid": "3029",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red"
+    },
+    {
+        "name": "The Bait",
+        "shortname": "Bait",
+        "hammerid": "1548",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "grey"
+    },
+    {
+        "name": "Temple Key",
+        "shortname": "Key",
+        "hammerid": "2554",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "yellow"
+    },
+    {
         "name": "Zombie Heal",
         "shortname": "ZM Heal",
         "hammerid": "3232",
@@ -211,83 +289,5 @@
                 "ui": true
             }
         ]
-    },
-    {
-        "name": "Fruit of Knowledge",
-        "shortname": "Fruit",
-        "hammerid": "3035",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "purple"
-    },
-    {
-        "name": "Flame of Magic",
-        "shortname": "Flame",
-        "hammerid": "3029",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "red"
-    },
-    {
-        "name": "Holy Magic",
-        "shortname": "Holy",
-        "hammerid": "1669",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "pink",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "1665",
-                "event": "OnPressed",
-                "mode": 4,
-                "cooldown": 1,
-                "maxuses": 15,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Ammo Magic",
-        "shortname": "Ammo",
-        "hammerid": "1627",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "gold",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "1623",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 90,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "The Bait",
-        "shortname": "Bait",
-        "hammerid": "1548",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "grey"
-    },
-    {
-        "name": "Temple Key",
-        "shortname": "Key",
-        "hammerid": "2554",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "yellow"
     }
 ]

--- a/entwatch/ze_hydroponic_garden.jsonc
+++ b/entwatch/ze_hydroponic_garden.jsonc
@@ -1,5 +1,68 @@
 [
     {
+        "name": "Beam",
+        "shortname": "Beam",
+        "hammerid": "2136",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2134",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Cube",
+        "shortname": "Cube",
+        "hammerid": "2104",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "grey",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2114",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Shield",
+        "shortname": "Shield",
+        "hammerid": "2124",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2118",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
         "name": "Zombie Stars",
         "shortname": "ZM Stars",
         "hammerid": "1937",
@@ -81,69 +144,6 @@
                 "event": "OnPressed",
                 "mode": 2,
                 "cooldown": 90,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Beam",
-        "shortname": "Beam",
-        "hammerid": "2136",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "blue",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "2134",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 60,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Cube",
-        "shortname": "Cube",
-        "hammerid": "2104",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "grey",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "2114",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 60,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Shield",
-        "shortname": "Shield",
-        "hammerid": "2124",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "blue",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "2118",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 60,
                 "maxuses": 0,
                 "message": true,
                 "ui": true

--- a/entwatch/ze_industrial_dejavu.jsonc
+++ b/entwatch/ze_industrial_dejavu.jsonc
@@ -1,32 +1,5 @@
 [
     {
-        "name": "Love Machinegun",
-        "shortname": "Penis",
-        "hammerid": "987",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "pink"
-    },
-    {
-        "name": "Hat",
-        "shortname": "Hat",
-        "hammerid": "977",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "grey"
-    },
-    {
-        "name": "Free Bird",
-        "shortname": "Bird",
-        "hammerid": "976",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "greyu"
-    },
-    {
         "name": "Cooler",
         "shortname": "Cooler",
         "hammerid": "1173",
@@ -62,72 +35,6 @@
                 "event": "OnPressed",
                 "mode": 2,
                 "cooldown": 65,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Heal",
-        "shortname": "ZM Heal",
-        "hammerid": "162",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "white",
-        "triggers": ["166"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "169",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 90,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Rage",
-        "shortname": "ZM Rage",
-        "hammerid": "155",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "red",
-        "triggers": ["153"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "156",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 120,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Vortex",
-        "shortname": "ZM Vortex",
-        "hammerid": "143",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "purple",
-        "triggers": ["147"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "144",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 120,
                 "maxuses": 0,
                 "message": true,
                 "ui": true
@@ -211,5 +118,98 @@
         "ui": true,
         "transfer": true,
         "color": "yellow"
+    },
+    {
+        "name": "Love Machinegun",
+        "shortname": "Penis",
+        "hammerid": "987",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "pink"
+    },
+    {
+        "name": "Hat",
+        "shortname": "Hat",
+        "hammerid": "977",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "grey"
+    },
+    {
+        "name": "Free Bird",
+        "shortname": "Bird",
+        "hammerid": "976",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "greyu"
+    },
+    {
+        "name": "Zombie Heal",
+        "shortname": "ZM Heal",
+        "hammerid": "162",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "white",
+        "triggers": ["166"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "169",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 90,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Rage",
+        "shortname": "ZM Rage",
+        "hammerid": "155",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["153"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "156",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 120,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Vortex",
+        "shortname": "ZM Vortex",
+        "hammerid": "143",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "purple",
+        "triggers": ["147"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "144",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 120,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
     }
 ]

--- a/entwatch/ze_last_man_standing_p.jsonc
+++ b/entwatch/ze_last_man_standing_p.jsonc
@@ -27,47 +27,6 @@
         ]
     },
     {
-        "name": "Fuel Can",
-        "shortname": "Fuel",
-        "hammerid": "13078",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "grey"
-    },
-    {
-        "name": "Zombie Shockwave",
-        "shortname": "ZM Shockwave",
-        "hammerid": "5071",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "yellow",
-        "triggers": ["5068"],
-        "handlers": [
-            {
-                "type": "game_ui",
-                "hammerid": "5065",
-                "event": "OnTrigger",
-                "mode": 2,
-                "cooldown": 7,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Antlion",
-        "shortname": "ZM Antlion",
-        "hammerid": "5050",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "yellow",
-        "triggers": ["5048"]
-    },
-    {
         "name": "Immunizer Backpack",
         "shortname": "Immunizer BP",
         "hammerid": "4544",
@@ -242,6 +201,100 @@
         ]
     },
     {
+        "name": "M60 Minigun",
+        "shortname": "Minigun",
+        "hammerid": "292",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "grey",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "297",
+                "event": "OnPressed",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Gauss Beam Rifle",
+        "shortname": "Beam",
+        "hammerid": "182",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "darkblue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "183",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 45,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Mines",
+        "shortname": "Mines",
+        "hammerid": "371",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "376",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 16,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Turret",
+        "shortname": "Turret",
+        "hammerid": "81",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "79",
+                "event": "OnPressed",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Mech",
+        "shortname": "Mech",
+        "hammerid": "234",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "blue",
+        "triggers": ["230"]
+    },
+    {
         "name": "Juggernaut",
         "shortname": "Juggernaut",
         "hammerid": "727",
@@ -259,6 +312,56 @@
         "ui": false,
         "transfer": false,
         "color": "grey"
+    },
+    {
+        "name": "Train Driver",
+        "shortname": "Train Driver",
+        "hammerid": "6",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue"
+    },
+    {
+        "name": "Fuel Can",
+        "shortname": "Fuel",
+        "hammerid": "13078",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "grey"
+    },
+    {
+        "name": "Zombie Shockwave",
+        "shortname": "ZM Shockwave",
+        "hammerid": "5071",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "yellow",
+        "triggers": ["5068"],
+        "handlers": [
+            {
+                "type": "game_ui",
+                "hammerid": "5065",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 7,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Antlion",
+        "shortname": "ZM Antlion",
+        "hammerid": "5050",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "yellow",
+        "triggers": ["5048"]
     },
     {
         "name": "Zombie Jumper",
@@ -327,27 +430,6 @@
         ]
     },
     {
-        "name": "Mines",
-        "shortname": "Mines",
-        "hammerid": "371",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "red",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "376",
-                "event": "OnPressed",
-                "mode": 3,
-                "cooldown": 0,
-                "maxuses": 16,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Zombie Summoner",
         "shortname": "ZM Summoner",
         "hammerid": "353",
@@ -368,48 +450,6 @@
         "triggers": ["337"]
     },
     {
-        "name": "M60 Minigun",
-        "shortname": "Minigun",
-        "hammerid": "292",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "grey",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "297",
-                "event": "OnPressed",
-                "mode": 1,
-                "cooldown": 0,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Gauss Beam Rifle",
-        "shortname": "Beam",
-        "hammerid": "182",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "darkblue",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "183",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 45,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Zombie Tank",
         "shortname": "ZM Tank",
         "hammerid": "159",
@@ -423,27 +463,6 @@
                 "type": "game_ui",
                 "hammerid": "170",
                 "event": "OnTrigger",
-                "mode": 1,
-                "cooldown": 0,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Turret",
-        "shortname": "Turret",
-        "hammerid": "81",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "red",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "79",
-                "event": "OnPressed",
                 "mode": 1,
                 "cooldown": 0,
                 "maxuses": 0,
@@ -483,24 +502,5 @@
         "transfer": false,
         "color": "red",
         "triggers": ["13197", "443", "870", "2571"]
-    },
-    {
-        "name": "Mech",
-        "shortname": "Mech",
-        "hammerid": "234",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "blue",
-        "triggers": ["230"]
-    },
-    {
-        "name": "Train Driver",
-        "shortname": "Train Driver",
-        "hammerid": "6",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "blue"
     }
 ]

--- a/entwatch/ze_lotr_isengard.jsonc
+++ b/entwatch/ze_lotr_isengard.jsonc
@@ -1,37 +1,6 @@
 [
     {
-        "name": "Torch",
-        "shortname": "Torch",
-        "hammerid": "2643",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "orange"
-    },
-    {
-        "name": "Zombie Spider",
-        "shortname": "ZM Spider",
-        "hammerid": "20309",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "grey",
-        "triggers": ["20295"],
-        "handlers": [
-            {
-                "type": "game_ui",
-                "hammerid": "20310",
-                "event": "OnTrigger",
-                "mode": 2,
-                "cooldown": 20,
-                "maxuses": 0,
-                "message": false,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Ent",
+        "name": "Tree Ent",
         "shortname": "Ent",
         "hammerid": "20501",
         "message": true,
@@ -57,27 +26,6 @@
                 "mode": 2,
                 "cooldown": 30,
                 "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Barricade",
-        "shortname": "Barricade",
-        "hammerid": "20532",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "grey",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "20529",
-                "event": "OnPressed",
-                "mode": 3,
-                "cooldown": 0,
-                "maxuses": 1,
                 "message": true,
                 "ui": true
             }
@@ -132,6 +80,58 @@
                 "cooldown": 0,
                 "maxuses": 1,
                 "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Barricade",
+        "shortname": "Barricade",
+        "hammerid": "20532",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "grey",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "20529",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Torch",
+        "shortname": "Torch",
+        "hammerid": "2643",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "orange"
+    },
+    {
+        "name": "Zombie Spider",
+        "shortname": "ZM Spider",
+        "hammerid": "20309",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "grey",
+        "triggers": ["20295"],
+        "handlers": [
+            {
+                "type": "game_ui",
+                "hammerid": "20310",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 20,
+                "maxuses": 0,
+                "message": false,
                 "ui": true
             }
         ]

--- a/entwatch/ze_lotr_mount_doom_p.jsonc
+++ b/entwatch/ze_lotr_mount_doom_p.jsonc
@@ -30,16 +30,6 @@
         ]
     },
     {
-        "name": "Zombie Nazgul",
-        "shortname": "ZM Nazgul",
-        "hammerid": "355",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "darkred",
-        "triggers": ["865"]
-    },
-    {
         "name": "Radio",
         "shortname": "Radio",
         "hammerid": "892",
@@ -59,5 +49,15 @@
                 "ui": true
             }
         ]
+    },
+    {
+        "name": "Zombie Nazgul",
+        "shortname": "ZM Nazgul",
+        "hammerid": "355",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "darkred",
+        "triggers": ["865"]
     }
 ]

--- a/entwatch/ze_minimal.jsonc
+++ b/entwatch/ze_minimal.jsonc
@@ -1,27 +1,5 @@
 [
     {
-        "name": "Zombie Slow",
-        "shortname": "ZM Slow",
-        "hammerid": "4182",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "blue",
-        "triggers": ["4184"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "4179",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 4,
-                "maxuses": 0,
-                "message": false,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Slow",
         "shortname": "Slow",
         "hammerid": "4167",
@@ -54,6 +32,90 @@
             {
                 "type": "button",
                 "hammerid": "4119",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Freezer",
+        "shortname": "Freezer",
+        "hammerid": "4040",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4035",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Laser Wall",
+        "shortname": "Wall",
+        "hammerid": "4010",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4005",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Gravity",
+        "shortname": "Gravity",
+        "hammerid": "3961",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "purple",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3958",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Push",
+        "shortname": "Push",
+        "hammerid": "3926",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3921",
                 "event": "OnPressed",
                 "mode": 2,
                 "cooldown": 70,
@@ -130,43 +192,23 @@
         ]
     },
     {
-        "name": "Freezer",
-        "shortname": "Freezer",
-        "hammerid": "4040",
+        "name": "Zombie Slow",
+        "shortname": "ZM Slow",
+        "hammerid": "4182",
         "message": true,
         "ui": true,
-        "transfer": true,
+        "transfer": false,
         "color": "blue",
+        "triggers": ["4184"],
         "handlers": [
             {
                 "type": "button",
-                "hammerid": "4035",
+                "hammerid": "4179",
                 "event": "OnPressed",
                 "mode": 2,
-                "cooldown": 70,
+                "cooldown": 4,
                 "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Laser Wall",
-        "shortname": "Wall",
-        "hammerid": "4010",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "red",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "4005",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 70,
-                "maxuses": 0,
-                "message": true,
+                "message": false,
                 "ui": true
             }
         ]
@@ -209,48 +251,6 @@
                 "event": "OnPressed",
                 "mode": 2,
                 "cooldown": 90,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Gravity",
-        "shortname": "Gravity",
-        "hammerid": "3961",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "purple",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "3958",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 70,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Push",
-        "shortname": "Push",
-        "hammerid": "3926",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "green",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "3921",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 70,
                 "maxuses": 0,
                 "message": true,
                 "ui": true

--- a/entwatch/ze_overlord.jsonc
+++ b/entwatch/ze_overlord.jsonc
@@ -282,6 +282,38 @@
         ]
     },
     {
+        "name": "Platinum Dragon Lord Armor",
+        "shortname": "Platinum Armor",
+        "hammerid": "7537",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["7535"],
+        "handlers": [
+            {
+                "type": "game_ui",
+                "hammerid": "7530",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 3.5,
+                "maxuses": 0,
+                "message": false,
+                "ui": true
+            },
+            {
+                "type": "game_ui",
+                "hammerid": "7531",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 8,
+                "maxuses": 0,
+                "message": false,
+                "ui": true
+            }
+        ]
+    },
+    {
         "name": "Zombie Ice",
         "shortname": "ZM Ice",
         "hammerid": "6506",
@@ -569,38 +601,6 @@
                 "cooldown": 100,
                 "maxuses": 0,
                 "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Platinum Dragon Lord Armor",
-        "shortname": "Platinum Armor",
-        "hammerid": "7537",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "red",
-        "triggers": ["7535"],
-        "handlers": [
-            {
-                "type": "game_ui",
-                "hammerid": "7530",
-                "event": "OnTrigger",
-                "mode": 2,
-                "cooldown": 3.5,
-                "maxuses": 0,
-                "message": false,
-                "ui": true
-            },
-            {
-                "type": "game_ui",
-                "hammerid": "7531",
-                "event": "OnTrigger",
-                "mode": 2,
-                "cooldown": 8,
-                "maxuses": 0,
-                "message": false,
                 "ui": true
             }
         ]

--- a/entwatch/ze_platformer_p.jsonc
+++ b/entwatch/ze_platformer_p.jsonc
@@ -1,93 +1,5 @@
 [
     {
-        "name": "Zombie Rocket Launcher",
-        "shortname": "ZM Rocket",
-        "hammerid": "3688",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "red",
-        "triggers": ["3705"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "3695",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 5,
-                "maxuses": 0,
-                "message": false,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Mines",
-        "shortname": "ZM Mines",
-        "hammerid": "3672",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "darkred",
-        "triggers": ["3676"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "3660",
-                "event": "OnPressed",
-                "mode": 3,
-                "cooldown": 0,
-                "maxuses": 5,
-                "message": false,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Earth Builder",
-        "shortname": "ZM Builder",
-        "hammerid": "3637",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "olive",
-        "triggers": ["3652"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "3639",
-                "event": "OnPressed",
-                "mode": 3,
-                "cooldown": 0,
-                "maxuses": 13,
-                "message": false,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Ladder",
-        "shortname": "ZM Ladder",
-        "hammerid": "3625",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "grey",
-        "triggers": ["3629"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "3616",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 20,
-                "maxuses": 0,
-                "message": false,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Flamethrower", // Mode 6 with 3600 math_counter ID
         "shortname": "Flamethrower",
         "hammerid": "3601",
@@ -228,6 +140,94 @@
                 "event": "OnPressed",
                 "mode": 2,
                 "cooldown": 40,
+                "maxuses": 0,
+                "message": false,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Rocket Launcher",
+        "shortname": "ZM Rocket",
+        "hammerid": "3688",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["3705"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3695",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 5,
+                "maxuses": 0,
+                "message": false,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Mines",
+        "shortname": "ZM Mines",
+        "hammerid": "3672",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "darkred",
+        "triggers": ["3676"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3660",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 5,
+                "message": false,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Earth Builder",
+        "shortname": "ZM Builder",
+        "hammerid": "3637",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "olive",
+        "triggers": ["3652"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3639",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 13,
+                "message": false,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Ladder",
+        "shortname": "ZM Ladder",
+        "hammerid": "3625",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "grey",
+        "triggers": ["3629"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3616",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 20,
                 "maxuses": 0,
                 "message": false,
                 "ui": true

--- a/entwatch/ze_s_a_m.jsonc
+++ b/entwatch/ze_s_a_m.jsonc
@@ -32,48 +32,6 @@
         ]
     },
     {
-        "name": "Asuna",
-        "shortname": "Asuna",
-        "hammerid": "11546",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "white",
-        "triggers": ["11111"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "11115",
-                "event": "OnPressed",
-                "mode": 4,
-                "cooldown": 60,
-                "maxuses": 3,
-                "message": true,
-                "ui": true
-            },
-            {
-                "type": "game_ui",
-                "hammerid": "11130",
-                "event": "OnTrigger",
-                "mode": 1,
-                "cooldown": 0,
-                "maxuses": 0,
-                "message": false,
-                "ui": true
-            },
-            {
-                "type": "game_ui",
-                "hammerid": "11131",
-                "event": "OnTrigger",
-                "mode": 2,
-                "cooldown": 7,
-                "maxuses": 0,
-                "message": false,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Kirito",
         "shortname": "Kirito",
         "hammerid": "11545",
@@ -116,129 +74,65 @@
         ]
     },
     {
-        "name": "Zombie Shield",
-        "shortname": "ZM Shield",
-        "hammerid": "11544",
+        "name": "Asuna",
+        "shortname": "Asuna",
+        "hammerid": "11546",
         "message": true,
         "ui": true,
         "transfer": false,
-        "color": "green",
-        "triggers": ["9027", "7532"],
+        "color": "white",
+        "triggers": ["11111"],
         "handlers": [
             {
                 "type": "button",
-                "hammerid": "7536",
+                "hammerid": "11115",
                 "event": "OnPressed",
-                "mode": 2,
+                "mode": 4,
                 "cooldown": 60,
-                "maxuses": 0,
+                "maxuses": 3,
                 "message": true,
                 "ui": true
             },
             {
-                "type": "button",
-                "hammerid": "7527",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 80,
+                "type": "game_ui",
+                "hammerid": "11130",
+                "event": "OnTrigger",
+                "mode": 1,
+                "cooldown": 0,
                 "maxuses": 0,
-                "message": true,
+                "message": false,
+                "ui": true
+            },
+            {
+                "type": "game_ui",
+                "hammerid": "11131",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 7,
+                "maxuses": 0,
+                "message": false,
                 "ui": true
             }
         ]
     },
     {
-        "name": "Zombie Stealth",
-        "shortname": "ZM Stealth",
-        "hammerid": "11543",
+        "name": "Alice",
+        "shortname": "Alice",
+        "hammerid": "11645",
         "message": true,
         "ui": true,
         "transfer": false,
         "color": "yellow",
-        "triggers": ["9023", "7504"],
+        "triggers": ["11643"],
         "handlers": [
             {
-                "type": "button",
-                "hammerid": "7508",
-                "event": "OnPressed",
+                "type": "game_ui",
+                "hammerid": "11712",
+                "event": "OnTrigger",
                 "mode": 2,
                 "cooldown": 60,
                 "maxuses": 0,
-                "message": true,
-                "ui": true
-            },
-            {
-                "type": "button",
-                "hammerid": "7498",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 80,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Gravity",
-        "shortname": "ZM Gravity",
-        "hammerid": "11542",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "purple",
-        "triggers": ["9019", "7465"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "7460",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 80,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            },
-            {
-                "type": "button",
-                "hammerid": "7469",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 60,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Ice",
-        "shortname": "ZM Ice",
-        "hammerid": "11537",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "blue",
-        "triggers": ["9007", "7434"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "7428",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 80,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            },
-            {
-                "type": "button",
-                "hammerid": "7438",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 60,
-                "maxuses": 0,
-                "message": true,
+                "message": false,
                 "ui": true
             }
         ]
@@ -430,13 +324,131 @@
         "color": "white"
     },
     {
-        "name": "Alice",
-        "shortname": "Alice",
-        "hammerid": "11645",
+        "name": "Zombie Shield",
+        "shortname": "ZM Shield",
+        "hammerid": "11544",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "green",
+        "triggers": ["9027", "7532"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "7536",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "button",
+                "hammerid": "7527",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 80,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Gravity",
+        "shortname": "ZM Gravity",
+        "hammerid": "11542",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "purple",
+        "triggers": ["9019", "7465"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "7460",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 80,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "button",
+                "hammerid": "7469",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Ice",
+        "shortname": "ZM Ice",
+        "hammerid": "11537",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "blue",
+        "triggers": ["9007", "7434"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "7428",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 80,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "button",
+                "hammerid": "7438",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Stealth",
+        "shortname": "ZM Stealth",
+        "hammerid": "11543",
         "message": true,
         "ui": true,
         "transfer": false,
         "color": "yellow",
-        "triggers": ["11643"]
+        "triggers": ["9023", "7504"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "7508",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "button",
+                "hammerid": "7498",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 80,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
     }
 ]

--- a/entwatch/ze_sandstorm_cs2.jsonc
+++ b/entwatch/ze_sandstorm_cs2.jsonc
@@ -1,37 +1,5 @@
 [
     {
-        "name": "Zombie Antlion",
-        "shortname": "ZM Antlion",
-        "hammerid": "11895",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "red",
-        "triggers": ["11896"],
-        "handlers": [
-            {
-                "type": "game_ui", // Mouse 2
-                "hammerid": "11886",
-                "event": "OnTrigger",
-                "mode": 2,
-                "cooldown": 40,
-                "maxuses": 0,
-                "message": false,
-                "ui": true
-            },
-            {
-                "type": "game_ui", // Mouse 1
-                "hammerid": "11888",
-                "event": "OnTrigger",
-                "mode": 1,
-                "cooldown": 0,
-                "maxuses": 0,
-                "message": false,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Earth Staff",
         "shortname": "Earth",
         "hammerid": "11116",
@@ -47,27 +15,6 @@
                 "mode": 2,
                 "cooldown": 60,
                 "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Sandstorm Staff",
-        "shortname": "Sandstorm",
-        "hammerid": "11127",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "yellow",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "11129",
-                "event": "OnPressed",
-                "mode": 4,
-                "cooldown": 15,
-                "maxuses": 1,
                 "message": true,
                 "ui": true
             }
@@ -158,6 +105,27 @@
         ]
     },
     {
+        "name": "Sandstorm Staff",
+        "shortname": "Sandstorm",
+        "hammerid": "11127",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "yellow",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "11129",
+                "event": "OnPressed",
+                "mode": 4,
+                "cooldown": 15,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
         "name": "Zombie Fire",
         "shortname": "ZM Fire",
         "hammerid": "11828",
@@ -197,6 +165,38 @@
                 "cooldown": 60,
                 "maxuses": 0,
                 "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Antlion",
+        "shortname": "ZM Antlion",
+        "hammerid": "11895",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["11896"],
+        "handlers": [
+            {
+                "type": "game_ui", // Mouse 2
+                "hammerid": "11886",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 40,
+                "maxuses": 0,
+                "message": false,
+                "ui": true
+            },
+            {
+                "type": "game_ui", // Mouse 1
+                "hammerid": "11888",
+                "event": "OnTrigger",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": false,
                 "ui": true
             }
         ]

--- a/entwatch/ze_scourge_p.jsonc
+++ b/entwatch/ze_scourge_p.jsonc
@@ -1,7 +1,7 @@
 [
     {
         "name": "Explosive Bow",
-        "shortname": "Explosive Bow",
+        "shortname": "Explosives",
         "hammerid": "780",
         "message": true,
         "ui": true,
@@ -42,27 +42,6 @@
         ]
     },
     {
-        "name": "Speed Potion",
-        "shortname": "Speed",
-        "hammerid": "743",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "yellow",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "741",
-                "event": "OnPressed",
-                "mode": 3,
-                "cooldown": 0,
-                "maxuses": 1,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Bow",
         "shortname": "Bow",
         "hammerid": "605",
@@ -84,27 +63,6 @@
         ]
     },
     {
-        "name": "Heal Potion",
-        "shortname": "Heal",
-        "hammerid": "486",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "pink",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "454",
-                "event": "OnPressed",
-                "mode": 3,
-                "cooldown": 0,
-                "maxuses": 1,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Barrel",
         "shortname": "Barrel",
         "hammerid": "613",
@@ -119,6 +77,27 @@
                 "event": "OnPressed",
                 "mode": 2,
                 "cooldown": 50,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Shotgun",
+        "shortname": "Shotgun",
+        "hammerid": "789",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "grey",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "769",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 10,
                 "maxuses": 0,
                 "message": true,
                 "ui": true
@@ -147,21 +126,42 @@
         ]
     },
     {
-        "name": "Shotgun",
-        "shortname": "Shotgun",
-        "hammerid": "789",
+        "name": "Heal Potion",
+        "shortname": "Heal",
+        "hammerid": "486",
         "message": true,
         "ui": true,
         "transfer": true,
-        "color": "grey",
+        "color": "pink",
         "handlers": [
             {
                 "type": "button",
-                "hammerid": "769",
+                "hammerid": "454",
                 "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 10,
-                "maxuses": 0,
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Speed Potion",
+        "shortname": "Speed",
+        "hammerid": "743",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "yellow",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "741",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
                 "message": true,
                 "ui": true
             }

--- a/entwatch/ze_serpentis_temple.jsonc
+++ b/entwatch/ze_serpentis_temple.jsonc
@@ -1,14 +1,5 @@
 [
     {
-        "name": "Torch",
-        "shortname": "Torch",
-        "hammerid": "10857",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "orange"
-    },
-    {
         "name": "Fire Snake",
         "shortname": "Fire",
         "hammerid": "10856",
@@ -70,6 +61,15 @@
                 "ui": true
             }
         ]
+    },
+    {
+        "name": "Torch",
+        "shortname": "Torch",
+        "hammerid": "10857",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "orange"
     },
     {
         "name": "Artefact", // Yes, I know wrong spelling, but this is sovl

--- a/entwatch/ze_shroomforest2_p.jsonc
+++ b/entwatch/ze_shroomforest2_p.jsonc
@@ -1,49 +1,5 @@
 [
     {
-        "name": "Zombie Shroom",
-        "shortname": "ZM Shroom",
-        "hammerid": "6355",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "green",
-        "triggers": ["8532"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "6352",
-                "event": "OnPlayerUse",
-                "mode": 2,
-                "cooldown": 75,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Cloud",
-        "shortname": "ZM Cloud",
-        "hammerid": "6349",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "grey",
-        "triggers": ["8530"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "6345",
-                "event": "OnPlayerUse",
-                "mode": 2,
-                "cooldown": 75,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Ammo",
         "shortname": "Ammo",
         "hammerid": "6170",
@@ -227,6 +183,50 @@
                 "event": "OnPlayerUse",
                 "mode": 2,
                 "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Shroom",
+        "shortname": "ZM Shroom",
+        "hammerid": "6355",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "green",
+        "triggers": ["8532"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "6352",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 75,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Cloud",
+        "shortname": "ZM Cloud",
+        "hammerid": "6349",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "grey",
+        "triggers": ["8530"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "6345",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 75,
                 "maxuses": 0,
                 "message": true,
                 "ui": true

--- a/entwatch/ze_shroomforest3_p.jsonc
+++ b/entwatch/ze_shroomforest3_p.jsonc
@@ -219,15 +219,6 @@
         ]
     },
     {
-        "name": "Key",
-        "shortname": "Key",
-        "hammerid": "1447",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "yellow"
-    },
-    {
         "name": "Fire",
         "shortname": "Fire",
         "hammerid": "1646",
@@ -312,6 +303,27 @@
         ]
     },
     {
+        "name": "Charmander",
+        "shortname": "Charmander",
+        "hammerid": "1751",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "orange",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1752",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
         "name": "Pikachu",
         "shortname": "Pikachu",
         "hammerid": "1762",
@@ -364,6 +376,15 @@
         ]
     },
     {
+        "name": "Key",
+        "shortname": "Key",
+        "hammerid": "1447",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "yellow"
+    },
+    {
         "name": "Zombie Ghastly",
         "shortname": "ZM Ghastly",
         "hammerid": "1783",
@@ -379,27 +400,6 @@
                 "event": "OnPressed",
                 "mode": 2,
                 "cooldown": 75,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Charmander",
-        "shortname": "Charmander",
-        "hammerid": "1751",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "orange",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "1752",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 60,
                 "maxuses": 0,
                 "message": true,
                 "ui": true

--- a/entwatch/ze_shroomforest_p.jsonc
+++ b/entwatch/ze_shroomforest_p.jsonc
@@ -1,26 +1,5 @@
 [
     {
-        "name": "Unlimited Ammo",
-        "shortname": "Ammo",
-        "hammerid": "1058",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "olive",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "1056",
-                "event": "OnPlayerUse",
-                "mode": 2,
-                "cooldown": 60,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Ice",
         "shortname": "Ice",
         "hammerid": "1209",
@@ -105,13 +84,25 @@
         ]
     },
     {
-        "name": "Key",
-        "shortname": "Key",
-        "hammerid": "1166",
+        "name": "Unlimited Ammo",
+        "shortname": "Ammo",
+        "hammerid": "1058",
         "message": true,
         "ui": true,
         "transfer": true,
-        "color": "olive"
+        "color": "olive",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1056",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
     },
     {
         "name": "Earth",
@@ -126,6 +117,27 @@
             {
                 "type": "button",
                 "hammerid": "1149",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Heal",
+        "shortname": "Heal",
+        "hammerid": "1126",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1121",
                 "event": "OnPlayerUse",
                 "mode": 2,
                 "cooldown": 60,
@@ -157,36 +169,6 @@
         ]
     },
     {
-        "name": "Heal",
-        "shortname": "Heal",
-        "hammerid": "1126",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "red",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "1121",
-                "event": "OnPlayerUse",
-                "mode": 2,
-                "cooldown": 60,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Gear Mechanism",
-        "shortname": "Gear",
-        "hammerid": "8030",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "olive"
-    },
-    {
         "name": "Ultimate Weapon",
         "shortname": "Ultima",
         "hammerid": "914",
@@ -206,5 +188,23 @@
                 "ui": true
             }
         ]
+    },
+    {
+        "name": "Gear Mechanism",
+        "shortname": "Gear",
+        "hammerid": "8030",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "olive"
+    },
+    {
+        "name": "Key",
+        "shortname": "Key",
+        "hammerid": "1166",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "olive"
     }
 ]

--- a/entwatch/ze_sit_caelum_paradisus.jsonc
+++ b/entwatch/ze_sit_caelum_paradisus.jsonc
@@ -21,15 +21,6 @@
         ]
     },
     {
-        "name": "Serverman",
-        "shortname": "Serverman",
-        "hammerid": "2472",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "grey"
-    },
-    {
         "name": "Ventus Staff",
         "shortname": "Wind",
         "hammerid": "2492",
@@ -91,6 +82,15 @@
                 "ui": true
             }
         ]
+    },
+    {
+        "name": "Serverman",
+        "shortname": "Serverman",
+        "hammerid": "2472",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "grey"
     },
     {
         "name": "Zombie Gravity",

--- a/entwatch/ze_skygarden.jsonc
+++ b/entwatch/ze_skygarden.jsonc
@@ -9,27 +9,6 @@
         "color": "grey"
     },
     {
-        "name": "Earth 2",
-        "shortname": "Earth 2",
-        "hammerid": "261",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "olive",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "262",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 50,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Earth 1",
         "shortname": "Earth 1",
         "hammerid": "706",
@@ -41,6 +20,27 @@
             {
                 "type": "button",
                 "hammerid": "704",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 50,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Earth 2",
+        "shortname": "Earth 2",
+        "hammerid": "261",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "olive",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "262",
                 "event": "OnPressed",
                 "mode": 2,
                 "cooldown": 50,
@@ -93,6 +93,27 @@
         ]
     },
     {
+        "name": "Wind 3",
+        "shortname": "Wind 3",
+        "hammerid": "697",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "1776",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 10,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
         "name": "Fire",
         "shortname": "Fire",
         "hammerid": "1574",
@@ -104,6 +125,27 @@
             {
                 "type": "button",
                 "hammerid": "845",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 40,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Ammo",
+        "shortname": "Ammo",
+        "hammerid": "2512",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "olive",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2496",
                 "event": "OnPressed",
                 "mode": 2,
                 "cooldown": 40,
@@ -134,27 +176,6 @@
         "triggers": ["1578"]
     },
     {
-        "name": "Wind 3",
-        "shortname": "Wind 3",
-        "hammerid": "697",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "green",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "1776",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 10,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Zombie Wind Shield",
         "shortname": "ZM Shield",
         "hammerid": "1100",
@@ -170,27 +191,6 @@
                 "event": "OnPressed",
                 "mode": 0,
                 "cooldown": 0,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Ammo",
-        "shortname": "Ammo",
-        "hammerid": "2512",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "olive",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "2496",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 40,
                 "maxuses": 0,
                 "message": true,
                 "ui": true

--- a/entwatch/ze_slender_escape_p.jsonc
+++ b/entwatch/ze_slender_escape_p.jsonc
@@ -1,20 +1,61 @@
 [
     {
-        "name": "Zombie Fire Slender",
-        "shortname": "ZM Slender",
-        "hammerid": "1257",
+        "name": "Lantern",
+        "shortname": "Lantern",
+        "hammerid": "252",
         "message": true,
         "ui": true,
-        "transfer": false,
-        "color": "orange",
-        "triggers": ["1259"],
+        "transfer": true,
+        "color": "yellow",
         "handlers": [
             {
-                "type": "game_ui",
-                "hammerid": "1267",
-                "event": "OnTrigger",
+                "type": "button",
+                "hammerid": "250",
+                "event": "OnPlayerUse",
                 "mode": 2,
-                "cooldown": 20,
+                "cooldown": 41, // Original 41.5 but rounded down
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Glowstick",
+        "shortname": "Glowstick",
+        "hammerid": "257",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "258",
+                "event": "OnPlayerUse",
+                "mode": 2,
+                "cooldown": 25,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Flashlight",
+        "shortname": "Flashlight",
+        "hammerid": "248",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "default",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "246",
+                "event": "OnPlayerUse",
+                "mode": 1,
+                "cooldown": 0,
                 "maxuses": 0,
                 "message": true,
                 "ui": true
@@ -41,6 +82,25 @@
                 "ui": true
             }
         ]
+    },
+    {
+        "name": "Fuel Can",
+        "shortname": "Fuel",
+        "hammerid": "436",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red"
+    },
+    {
+        "name": "Barrel",
+        "shortname": "Barrel",
+        "hammerid": "364",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "grey",
+        "triggers": ["360"]
     },
     {
         "name": "Zombie Spider",
@@ -107,86 +167,26 @@
         ]
     },
     {
-        "name": "Fuel Can",
-        "shortname": "Fuel",
-        "hammerid": "436",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "red"
-    },
-    {
-        "name": "Lantern",
-        "shortname": "Lantern",
-        "hammerid": "252",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "yellow",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "250",
-                "event": "OnPlayerUse",
-                "mode": 2,
-                "cooldown": 41, // Original 41.5 but rounded down
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Glowstick",
-        "shortname": "Glowstick",
-        "hammerid": "257",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "green",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "258",
-                "event": "OnPlayerUse",
-                "mode": 2,
-                "cooldown": 25,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Flashlight",
-        "shortname": "Flashlight",
-        "hammerid": "248",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "default",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "246",
-                "event": "OnPlayerUse",
-                "mode": 1,
-                "cooldown": 0,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Barrel",
-        "shortname": "Barrel",
-        "hammerid": "364",
+        "name": "Zombie Fire Slender",
+        "shortname": "ZM Slender",
+        "hammerid": "1257",
         "message": true,
         "ui": true,
         "transfer": false,
-        "color": "grey",
-        "triggers": ["360"]
+        "color": "orange",
+        "triggers": ["1259"],
+        "handlers": [
+            {
+                "type": "game_ui",
+                "hammerid": "1267",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 20,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
     },
     {
         "name": "Zombie Slenderman",

--- a/entwatch/ze_steyliff_grove.jsonc
+++ b/entwatch/ze_steyliff_grove.jsonc
@@ -135,6 +135,289 @@
         ]
     },
     {
+        "name": "Aero Magic",
+        "shortname": "Wind",
+        "hammerid": "16851",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "16854",
+                "event": "OnPressed",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "16857",
+                "mode": 6,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Benefic Magic",
+        "shortname": "Benefic",
+        "hammerid": "17116",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "white",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "17118",
+                "event": "OnPressed",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "17120",
+                "mode": 6,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Summon Magic",
+        "shortname": "Summon",
+        "hammerid": "17212",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "17207",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Elusive Magic",
+        "shortname": "Elusive",
+        "hammerid": "17295",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "pink",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "17299",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 15,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Avant Magic",
+        "shortname": "Avant",
+        "hammerid": "17307",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "pink",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "17311",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 15,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Elixir Magic 1",
+        "shortname": "Elixir 1",
+        "hammerid": "16888",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "pink",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "16904",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Elixir Magic 2",
+        "shortname": "Elixir 2",
+        "hammerid": "16902",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "pink",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "16886",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Dia Magic 1",
+        "shortname": "Dia 1",
+        "hammerid": "16913",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "pink",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "16911",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Dia Magic 2",
+        "shortname": "Dia 2",
+        "hammerid": "16921",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "pink",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "16919",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Holy Sword",
+        "shortname": "Holy Sword",
+        "hammerid": "17322",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "yellow",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "17324",
+                "event": "OnPressed",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "17326",
+                "mode": 6,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Dark Sword",
+        "shortname": "Dark Sword",
+        "hammerid": "17337",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "purple",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "17339",
+                "event": "OnPressed",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "17342",
+                "mode": 6,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Malefic Magic",
+        "shortname": "ZM Malefic",
+        "hammerid": "17073",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["17071"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "17068",
+                "event": "OnPressed",
+                "mode": 1,
+                "cooldown": 0,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "counter",
+                "hammerid": "17067",
+                "mode": 6,
+                "ui": true
+            }
+        ]
+    },
+    {
         "name": "Zombie Ward Magic",
         "shortname": "ZM Ward",
         "hammerid": "16604",
@@ -353,289 +636,6 @@
             {
                 "type": "counter",
                 "hammerid": "16840",
-                "mode": 6,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Aero Magic",
-        "shortname": "Wind",
-        "hammerid": "16851",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "green",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "16854",
-                "event": "OnPressed",
-                "mode": 1,
-                "cooldown": 0,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            },
-            {
-                "type": "counter",
-                "hammerid": "16857",
-                "mode": 6,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Elixir Magic 2",
-        "shortname": "Elixir 2",
-        "hammerid": "16902",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "pink",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "16886",
-                "event": "OnPressed",
-                "mode": 3,
-                "cooldown": 0,
-                "maxuses": 1,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Elixir Magic 1",
-        "shortname": "Elixir 1",
-        "hammerid": "16888",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "pink",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "16904",
-                "event": "OnPressed",
-                "mode": 3,
-                "cooldown": 0,
-                "maxuses": 1,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Dia Magic 1",
-        "shortname": "Dia 1",
-        "hammerid": "16913",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "pink",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "16911",
-                "event": "OnPressed",
-                "mode": 3,
-                "cooldown": 0,
-                "maxuses": 1,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Dia Magic 2",
-        "shortname": "Dia 2",
-        "hammerid": "16921",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "pink",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "16919",
-                "event": "OnPressed",
-                "mode": 3,
-                "cooldown": 0,
-                "maxuses": 1,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Malefic Magic",
-        "shortname": "ZM Malefic",
-        "hammerid": "17073",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "red",
-        "triggers": ["17071"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "17068",
-                "event": "OnPressed",
-                "mode": 1,
-                "cooldown": 0,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            },
-            {
-                "type": "counter",
-                "hammerid": "17067",
-                "mode": 6,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Benefic Magic",
-        "shortname": "Benefic",
-        "hammerid": "17116",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "white",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "17118",
-                "event": "OnPressed",
-                "mode": 1,
-                "cooldown": 0,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            },
-            {
-                "type": "counter",
-                "hammerid": "17120",
-                "mode": 6,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Summon Magic",
-        "shortname": "Summon",
-        "hammerid": "17212",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "red",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "17207",
-                "event": "OnPressed",
-                "mode": 3,
-                "cooldown": 0,
-                "maxuses": 1,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Elusive Magic",
-        "shortname": "Elusive",
-        "hammerid": "17295",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "pink",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "17299",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 15,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Avant Magic",
-        "shortname": "Avant",
-        "hammerid": "17307",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "pink",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "17311",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 15,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Holy Sword",
-        "shortname": "Holy Sword",
-        "hammerid": "17322",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "yellow",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "17324",
-                "event": "OnPressed",
-                "mode": 1,
-                "cooldown": 0,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            },
-            {
-                "type": "counter",
-                "hammerid": "17326",
-                "mode": 6,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Dark Sword",
-        "shortname": "Dark Sword",
-        "hammerid": "17337",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "purple",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "17339",
-                "event": "OnPressed",
-                "mode": 1,
-                "cooldown": 0,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            },
-            {
-                "type": "counter",
-                "hammerid": "17342",
                 "mode": 6,
                 "ui": true
             }

--- a/entwatch/ze_stilshrine_of_miriam.jsonc
+++ b/entwatch/ze_stilshrine_of_miriam.jsonc
@@ -1,35 +1,5 @@
 [
     {
-        "name": "Sword of Kings",
-        "shortname": "Sword",
-        "hammerid": "3107",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "yellow"
-    },
-    {
-        "name": "Esper Mateus",
-        "shortname": "Mateus",
-        "hammerid": "2794",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "blue",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "2256",
-                "event": "OnPressed",
-                "mode": 4,
-                "cooldown": 15,
-                "maxuses": 1,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Heal Magick",
         "shortname": "Heal",
         "hammerid": "2662",
@@ -196,6 +166,36 @@
                 "ui": true
             }
         ]
+    },
+    {
+        "name": "Esper Mateus",
+        "shortname": "Mateus",
+        "hammerid": "2794",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "blue",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2256",
+                "event": "OnPressed",
+                "mode": 4,
+                "cooldown": 15,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Sword of Kings",
+        "shortname": "Sword",
+        "hammerid": "3107",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "yellow"
     },
     {
         "name": "Zombie Haste",

--- a/entwatch/ze_tesv_skyrim_p.jsonc
+++ b/entwatch/ze_tesv_skyrim_p.jsonc
@@ -150,124 +150,6 @@
         ]
     },
     {
-        "name": "Wolf",
-        "shortname": "Wolf",
-        "hammerid": "29224",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "darkred",
-        "triggers": ["987"],
-        "handlers": [
-            {
-                "type": "game_ui", // M1
-                "hammerid": "29229",
-                "event": "OnTrigger",
-                "mode": 2,
-                "cooldown": 2,
-                "maxuses": 0,
-                "message": false,
-                "ui": true
-            },
-            {
-                "type": "game_ui", // M2
-                "hammerid": "29237",
-                "event": "OnTrigger",
-                "mode": 2,
-                "cooldown": 0,
-                "maxuses": 25,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Troll",
-        "shortname": "Troll",
-        "hammerid": "29179",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "darkred",
-        "triggers": ["990"],
-        "handlers": [
-            {
-                "type": "game_ui", // M1
-                "hammerid": "29184",
-                "event": "OnTrigger",
-                "mode": 2,
-                "cooldown": 2,
-                "maxuses": 0,
-                "message": false,
-                "ui": true
-            },
-            {
-                "type": "game_ui", // M2
-                "hammerid": "29185",
-                "event": "OnTrigger",
-                "mode": 2,
-                "cooldown": 35,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Giant",
-        "shortname": "Giant",
-        "hammerid": "29267",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "darkred",
-        "triggers": ["994"],
-        "handlers": [
-            {
-                "type": "game_ui", // M1
-                "hammerid": "29270",
-                "event": "OnTrigger",
-                "mode": 2,
-                "cooldown": 5,
-                "maxuses": 0,
-                "message": false,
-                "ui": true
-            },
-            {
-                "type": "game_ui", // M2
-                "hammerid": "29271",
-                "event": "OnTrigger",
-                "mode": 2,
-                "cooldown": 15,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Dragonpriest",
-        "shortname": "Dragonpriest",
-        "hammerid": "29313",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "purple",
-        "triggers": ["1088"],
-        "handlers": [
-            {
-                "type": "game_ui",
-                "hammerid": "29317",
-                "event": "OnTrigger",
-                "mode": 3,
-                "cooldown": 0,
-                "maxuses": 1,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Freeze Staff",
         "shortname": "Freeze",
         "hammerid": "225",
@@ -327,8 +209,8 @@
         "transfer": true,
         "color": "white"
     },
-    { // level 4
-        "name": "Elder Scroll",
+    {
+        "name": "Elder Scroll", // level 4
         "shortname": "Scroll",
         "hammerid": "406",
         "message": true,
@@ -336,13 +218,131 @@
         "transfer": true,
         "color": "yellow"
     },
-    { // level 5
-        "name": "Elder Scroll",
+    {
+        "name": "Elder Scroll", // level 5
         "shortname": "Scroll",
         "hammerid": "723",
         "message": true,
         "ui": true,
         "transfer": true,
         "color": "yellow"
+    },
+    {
+        "name": "Zombie Wolf",
+        "shortname": "ZM Wolf",
+        "hammerid": "29224",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "darkred",
+        "triggers": ["987"],
+        "handlers": [
+            {
+                "type": "game_ui", // M1
+                "hammerid": "29229",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 2,
+                "maxuses": 0,
+                "message": false,
+                "ui": true
+            },
+            {
+                "type": "game_ui", // M2
+                "hammerid": "29237",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 0,
+                "maxuses": 25,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Troll",
+        "shortname": "ZM Troll",
+        "hammerid": "29179",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "darkred",
+        "triggers": ["990"],
+        "handlers": [
+            {
+                "type": "game_ui", // M1
+                "hammerid": "29184",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 2,
+                "maxuses": 0,
+                "message": false,
+                "ui": true
+            },
+            {
+                "type": "game_ui", // M2
+                "hammerid": "29185",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 35,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Giant",
+        "shortname": "ZM Giant",
+        "hammerid": "29267",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "darkred",
+        "triggers": ["994"],
+        "handlers": [
+            {
+                "type": "game_ui", // M1
+                "hammerid": "29270",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 5,
+                "maxuses": 0,
+                "message": false,
+                "ui": true
+            },
+            {
+                "type": "game_ui", // M2
+                "hammerid": "29271",
+                "event": "OnTrigger",
+                "mode": 2,
+                "cooldown": 15,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Dragonpriest",
+        "shortname": "ZM Dragonpriest",
+        "hammerid": "29313",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "purple",
+        "triggers": ["1088"],
+        "handlers": [
+            {
+                "type": "game_ui",
+                "hammerid": "29317",
+                "event": "OnTrigger",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
     }
 ]

--- a/entwatch/ze_tyranny_cs2.jsonc
+++ b/entwatch/ze_tyranny_cs2.jsonc
@@ -1,159 +1,5 @@
 [
     {
-        "name": "Zombie Invisibility",
-        "shortname": "ZM Invis",
-        "hammerid": "5298",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "yellow",
-        "triggers": ["5299"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "5302",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 90,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Drug",
-        "shortname": "ZM Drug",
-        "hammerid": "5287",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "blue",
-        "triggers": ["5288"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "5292",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 90,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Gravity",
-        "shortname": "ZM Gravity",
-        "hammerid": "5317",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "pink",
-        "triggers": ["5315"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "5282",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 90,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Poison",
-        "shortname": "ZM Poison",
-        "hammerid": "5306",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "green",
-        "triggers": ["5307"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "5309",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 90,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Fire",
-        "shortname": "ZM Fire",
-        "hammerid": "5261",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "red",
-        "triggers": ["5262"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "5256",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 90,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Heal",
-        "shortname": "ZM Heal",
-        "hammerid": "5242",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "red",
-        "triggers": ["5243"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "5247",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 20,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Killer",
-        "shortname": "ZM Killer",
-        "hammerid": "5232",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "red",
-        "triggers": ["5233"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "5237",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 120,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Ammo",
         "shortname": "Ammo",
         "hammerid": "5155",
@@ -336,6 +182,160 @@
                 "event": "OnPressed",
                 "mode": 2,
                 "cooldown": 60,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Invisibility",
+        "shortname": "ZM Invis",
+        "hammerid": "5298",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "yellow",
+        "triggers": ["5299"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5302",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 90,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Drug",
+        "shortname": "ZM Drug",
+        "hammerid": "5287",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "blue",
+        "triggers": ["5288"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5292",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 90,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Gravity",
+        "shortname": "ZM Gravity",
+        "hammerid": "5317",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "pink",
+        "triggers": ["5315"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5282",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 90,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Poison",
+        "shortname": "ZM Poison",
+        "hammerid": "5306",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "green",
+        "triggers": ["5307"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5309",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 90,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Fire",
+        "shortname": "ZM Fire",
+        "hammerid": "5261",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["5262"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5256",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 90,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Heal",
+        "shortname": "ZM Heal",
+        "hammerid": "5242",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["5243"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5247",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 20,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Killer",
+        "shortname": "ZM Killer",
+        "hammerid": "5232",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["5233"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "5237",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 120,
                 "maxuses": 0,
                 "message": true,
                 "ui": true

--- a/entwatch/ze_uchiha_legacy.jsonc
+++ b/entwatch/ze_uchiha_legacy.jsonc
@@ -126,6 +126,48 @@
         ]
     },
     {
+        "name": "Rashomon",
+        "shortname": "Rashomon",
+        "hammerid": "176",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "red",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "172",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Mokuton",
+        "shortname": "Mokuton",
+        "hammerid": "169",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "orange",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "165",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
         "name": "Zombie Rinnegan",
         "shortname": "ZM Rinnegan",
         "hammerid": "227",
@@ -230,48 +272,6 @@
                 "mode": 2,
                 "cooldown": 40,
                 "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Rashomon",
-        "shortname": "Rashomon",
-        "hammerid": "176",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "red",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "172",
-                "event": "OnPressed",
-                "mode": 3,
-                "cooldown": 0,
-                "maxuses": 1,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Mokuton",
-        "shortname": "Mokuton",
-        "hammerid": "169",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "orange",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "165",
-                "event": "OnPressed",
-                "mode": 3,
-                "cooldown": 0,
-                "maxuses": 1,
                 "message": true,
                 "ui": true
             }

--- a/entwatch/ze_zertinan.jsonc
+++ b/entwatch/ze_zertinan.jsonc
@@ -1,232 +1,5 @@
 [
     {
-        "name": "Ammo",
-        "shortname": "Ammo",
-        "hammerid": "2953",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "olive",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "2160",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 90,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Cure 2",
-        "shortname": "Cure 2",
-        "hammerid": "2960",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "white",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "2961",
-                "event": "OnPressed",
-                "mode": 3,
-                "cooldown": 0,
-                "maxuses": 1,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Cure 1",
-        "shortname": "Cure 1",
-        "hammerid": "2967",
-        "message": true,
-        "ui": true,
-        "transfer": true,
-        "color": "white",
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "2968",
-                "event": "OnPressed",
-                "mode": 3,
-                "cooldown": 0,
-                "maxuses": 1,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Gravity",
-        "shortname": "ZM Gravity",
-        "hammerid": "4135",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "purple",
-        "triggers": ["4701"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "4133",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 70,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Warp",
-        "shortname": "ZM Warp",
-        "hammerid": "4159",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "red",
-        "triggers": ["4136"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 70,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Invisibility",
-        "shortname": "ZM Invis",
-        "hammerid": "4167",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "yellow",
-        "triggers": ["4165"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "4163",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 70,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Sleep",
-        "shortname": "ZM Sleep",
-        "hammerid": "3823",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "purple",
-        "triggers": ["4157"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "3821",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 70,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Poison",
-        "shortname": "ZM Poison",
-        "hammerid": "4218",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "green",
-        "triggers": ["3824"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "4216",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 70,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Shield",
-        "shortname": "ZM Shield",
-        "hammerid": "4223",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "yellow",
-        "triggers": ["4224"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "4221",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 70,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Heal",
-        "shortname": "ZM Heal",
-        "hammerid": "4238",
-        "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "red",
-        "triggers": ["4236"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "4243",
-                "event": "OnPressed",
-                "mode": 2,
-                "cooldown": 70,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            },
-            {
-                "type": "game_ui",
-                "hammerid": "9050",
-                "event": "OnEqualTo",
-                "mode": 2,
-                "cooldown": 70,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
         "name": "Wind",
         "shortname": "Wind",
         "hammerid": "2844",
@@ -405,6 +178,27 @@
         ]
     },
     {
+        "name": "Ammo",
+        "shortname": "Ammo",
+        "hammerid": "2953",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "olive",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2160",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 90,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
         "name": "Esper Mateus Summon",
         "shortname": "Mateus",
         "hammerid": "3787",
@@ -483,6 +277,212 @@
                 "mode": 3,
                 "cooldown": 0,
                 "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Cure 1",
+        "shortname": "Cure 1",
+        "hammerid": "2967",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "white",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2968",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Cure 2",
+        "shortname": "Cure 2",
+        "hammerid": "2960",
+        "message": true,
+        "ui": true,
+        "transfer": true,
+        "color": "white",
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "2961",
+                "event": "OnPressed",
+                "mode": 3,
+                "cooldown": 0,
+                "maxuses": 1,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Gravity",
+        "shortname": "ZM Gravity",
+        "hammerid": "4135",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "purple",
+        "triggers": ["4701"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4133",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Warp",
+        "shortname": "ZM Warp",
+        "hammerid": "4159",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["4136"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Invisibility",
+        "shortname": "ZM Invis",
+        "hammerid": "4167",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "yellow",
+        "triggers": ["4165"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4163",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Sleep",
+        "shortname": "ZM Sleep",
+        "hammerid": "3823",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "purple",
+        "triggers": ["4157"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "3821",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Poison",
+        "shortname": "ZM Poison",
+        "hammerid": "4218",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "green",
+        "triggers": ["3824"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4216",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Shield",
+        "shortname": "ZM Shield",
+        "hammerid": "4223",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "yellow",
+        "triggers": ["4224"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4221",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            }
+        ]
+    },
+    {
+        "name": "Zombie Heal",
+        "shortname": "ZM Heal",
+        "hammerid": "4238",
+        "message": true,
+        "ui": true,
+        "transfer": false,
+        "color": "red",
+        "triggers": ["4236"],
+        "handlers": [
+            {
+                "type": "button",
+                "hammerid": "4243",
+                "event": "OnPressed",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
+                "message": true,
+                "ui": true
+            },
+            {
+                "type": "game_ui",
+                "hammerid": "9050",
+                "event": "OnEqualTo",
+                "mode": 2,
+                "cooldown": 70,
+                "maxuses": 0,
                 "message": true,
                 "ui": true
             }


### PR DESCRIPTION
This pull request updates all entwatch configs and reorders how items are listed. With the upcoming HUD and tracking update from tilgep, a benefit would be the control over how items are displayed.

The main order for items in this pull request goes as follows:
1. The core human items (e.g. earth/wind/fire)
2. Human side items (potions, one-time use items, triggers)
3. Zombie items