### PR TITLE
Fix visualizer stage 6 boss health scaling

### DIFF
--- a/stripper/ze_visualizer/3132#entityLumpName.jsonc
+++ b/stripper/ze_visualizer/3132#entityLumpName.jsonc
@@ -1,0 +1,12 @@
+{
+	// Fix stage 6 boss health scaling not excluding zombies
+	"modify": {
+		"match": {
+			"classname": "trigger_multiple",
+			"targetname": "[PR#]boss_add_hp"
+		},
+		"insert": {
+			"filtername": "[PR#]filter_humans"
+		}
+	}
+}


### PR DESCRIPTION
The boss health trigger on stage 6 of ze_visualizer is not filtered, leading to the rare scenario where the health scaling may end up scaling for all players, both humans and zombies, present on the platform rather than just the humans. This behavior is not intended by the mapper. I have also forwarded this issue to Seth but he has been busy and does not have the time to update. Once the map gets updated, this stripper can be removed.

