### PR TITLE
Update config for ze_oot_shadowtemple

### DIFF
--- a/bosshud/ze_oot_shadowtemple.jsonc
+++ b/bosshud/ze_oot_shadowtemple.jsonc
@@ -27,8 +27,9 @@
     "counter": "b_handhpcounter"
   },
   {
-    "name": "Redead",
+    "hitmarkeronly": true,
     "multitrigger": true,
+    "showbeaten": false,
     "templated": true,
     "breakable": "Redead_Health"
   }

--- a/bosshud/ze_oot_shadowtemple.jsonc
+++ b/bosshud/ze_oot_shadowtemple.jsonc
@@ -1,29 +1,29 @@
 [
-    {
-        "name":             "Wallmaster",
-        "multitrigger":     true,
-        "templated":        true,
-        "breakable":        "Wallmaster_Health"
-    },
-    {
-        "name":             "Gibdo",
-        "multitrigger":     true,
-        "templated":        true,
-        "breakable":        "Gibdo_Health"
-    },
-    {
-        "name":             "Stalfos",
-        "multitrigger":     true,
-        "templated":        true,
-        "breakable":        "Stalfos_Health"
-    },
-    {
-        "name":             "Bongo Eyes",
-        "counter":          "b_hpcounter"
-    },
-    {
-        "name":             "Bongo Hands",
-        "multitrigger":     true,
-        "counter":          "b_handhpcounter"
-    }
+  {
+    "name": "Wallmaster",
+    "multitrigger": true,
+    "templated": true,
+    "breakable": "Wallmaster_Health"
+  },
+  {
+    "name": "Gibdo",
+    "multitrigger": true,
+    "templated": true,
+    "breakable": "Gibdo_Health"
+  },
+  {
+    "name": "Stalfos",
+    "multitrigger": true,
+    "templated": true,
+    "breakable": "Stalfos_Health"
+  },
+  {
+    "name": "Bongo Eyes",
+    "counter": "b_hpcounter"
+  },
+  {
+    "name": "Bongo Hands",
+    "multitrigger": true,
+    "counter": "b_handhpcounter"
+  }
 ]

--- a/bosshud/ze_oot_shadowtemple.jsonc
+++ b/bosshud/ze_oot_shadowtemple.jsonc
@@ -25,5 +25,11 @@
     "name": "Bongo Hands",
     "multitrigger": true,
     "counter": "b_handhpcounter"
+  },
+  {
+    "name": "Redead",
+    "multitrigger": true,
+    "templated": true,
+    "breakable": "Redead_Health"
   }
 ]


### PR DESCRIPTION
Fixes redead npc health not displaying as reported by Afastdo [here](https://discord.com/channels/223673175571955712/1446809675965141053/1520368132051439687).