### PR TITLE
Add config for ze_atix_apocalypse_p

### DIFF
--- a/entwatch/ze_atix_apocalypse_p.jsonc
+++ b/entwatch/ze_atix_apocalypse_p.jsonc
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "Flamethrower",
+    "shortname": "Flamethrower",
+    "hammerid": "7294",
+    "message": true,
+    "ui": true,
+    "transfer": true,
+    "color": "orange",
+    "handlers": [
+      {
+        "type": "button",
+        "hammerid": "7295"
+      },
+      {
+        "hammerid": "7298",
+        "event": "OnPass",
+        "mode": 2,
+        "cooldown": 45,
+        "maxuses": 0,
+        "message": true,
+        "ui": true
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Adds missing entwatch config for ze_atix_apocalypse_p as reported by Afastado [here](https://discord.com/channels/223673175571955712/1446809675965141053/1521321888230539374).