### PR TITLE
Update config for ze_desperate_soul

### DIFF
--- a/bosshud/ze_desperate_soul.jsonc
+++ b/bosshud/ze_desperate_soul.jsonc
@@ -33,5 +33,11 @@
     "templated": true,
     "timeout": 1.0,
     "breakable": "NPC_Ronka_Phys_2"
+  },
+  {
+    "name": "Spider Wall",
+    "multitrigger": true,
+    "showbeaten": false,
+    "breakable": "S4_G_Spider_Wall"
   }
 ]

--- a/bosshud/ze_desperate_soul.jsonc
+++ b/bosshud/ze_desperate_soul.jsonc
@@ -1,28 +1,28 @@
 [
-    {
-        "name":             "Diablo",
-        "breakable":        "S1_Diablo_Box"
-    },
-    {
-        "name":             "Nidhogg",
-        "counter":          "S0_Hogg_Hp_Counter"
-    },
-    {
-        "name":             "Kaleda",
-        "counter":          "Kaleda_HP_Counter_2",
-        "backup":           "Kaleda_HP_Counter_1",
-        "iterator":         "Counter_Boss_HP_1"
-    },
-    {
-        "name":             "Diablo",
-        "counter":          "Diablo_HP_Counter_2",
-        "backup":           "Diablo_HP_Counter_1",
-        "iterator":         "Counter_Boss_HP_1"
-    },
-    {
-        "name":             "Nidhogg",
-        "counter":          "Hogg_Hp_Counter_2",
-        "backup":           "Hogg_Hp_Counter_3",
-        "iterator":         "Counter_Boss_HP_1"
-    }
+  {
+    "name": "Diablo",
+    "breakable": "S1_Diablo_Box"
+  },
+  {
+    "name": "Nidhogg",
+    "counter": "S0_Hogg_Hp_Counter"
+  },
+  {
+    "name": "Kaleda",
+    "counter": "Kaleda_HP_Counter_2",
+    "backup": "Kaleda_HP_Counter_1",
+    "iterator": "Counter_Boss_HP_1"
+  },
+  {
+    "name": "Diablo",
+    "counter": "Diablo_HP_Counter_2",
+    "backup": "Diablo_HP_Counter_1",
+    "iterator": "Counter_Boss_HP_1"
+  },
+  {
+    "name": "Nidhogg",
+    "counter": "Hogg_Hp_Counter_2",
+    "backup": "Hogg_Hp_Counter_3",
+    "iterator": "Counter_Boss_HP_1"
+  }
 ]

--- a/bosshud/ze_desperate_soul.jsonc
+++ b/bosshud/ze_desperate_soul.jsonc
@@ -24,5 +24,14 @@
     "counter": "Hogg_Hp_Counter_2",
     "backup": "Hogg_Hp_Counter_3",
     "iterator": "Counter_Boss_HP_1"
+  },
+  {
+    "name": "Ronka",
+    "minorhud": true,
+    "multitrigger": true,
+    "showbeaten": false,
+    "templated": true,
+    "timeout": 1.0,
+    "breakable": "NPC_Ronka_Phys_2"
   }
 ]


### PR DESCRIPTION
Fixes missing mini-boss on ze_desperate_soul and missing health display for breakable wall on stage 5 as reported by Afastado [here](https://discord.com/channels/223673175571955712/1446809675965141053/1522514531559931965) and [here](https://discord.com/channels/223673175571955712/1446809675965141053/1523464278726934570)
