### PR TITLE
Update config for ze_eternal_grove

### DIFF
--- a/bosshud/ze_eternal_grove.jsonc
+++ b/bosshud/ze_eternal_grove.jsonc
@@ -9,6 +9,6 @@
     "multitrigger": true,
     "templated": true,
     "showbeaten": false,
-    "counter": "i_templeguardian_hp"
+    "breakable": "i_templeguardian_hp"
   }
 ]

--- a/bosshud/ze_eternal_grove.jsonc
+++ b/bosshud/ze_eternal_grove.jsonc
@@ -1,14 +1,14 @@
 [
-    {
-        "name": "Minotaur God",
-        "breakable": "i_minotaurgod_hp"
-    },
-    // GFL does not display NPC health
-    {
-        "hitmarkeronly": true,
-        "multitrigger": true,
-        "templated": true,
-        "showbeaten": false,
-        "counter": "i_templeguardian_hp"
-    }
+  {
+    "name": "Minotaur God",
+    "breakable": "i_minotaurgod_hp"
+  },
+  // GFL does not display NPC health
+  {
+    "hitmarkeronly": true,
+    "multitrigger": true,
+    "templated": true,
+    "showbeaten": false,
+    "counter": "i_templeguardian_hp"
+  }
 ]


### PR DESCRIPTION
Fixes hitmarkers not showing up for temple guardian NPC as reported by Afastado [here](https://discord.com/channels/223673175571955712/1446809675965141053/1522870329855443045)