### PR TITLE
Update entwatch config for ze_diddle

### DIFF
--- a/entwatch/ze_diddle.jsonc
+++ b/entwatch/ze_diddle.jsonc
@@ -191,7 +191,7 @@
   {
     "name": "Diddle Cannon",
     "shortname": "Cannon",
-    "hammerid": "7471",
+    "hammerid": "8163",
     "message": true,
     "ui": true,
     "transfer": true,
@@ -199,7 +199,7 @@
     "handlers": [
       {
         "type": "button",
-        "hammerid": "7478",
+        "hammerid": "8159",
         "event": "OnPressed",
         "mode": 1,
         "cooldown": 0,


### PR DESCRIPTION
Fixes incorrect hammerids for diddle cannon.