### PR TITLE
Update bosshud config for ze_desperate_soul

### DIFF
--- a/bosshud/ze_desperate_soul.jsonc
+++ b/bosshud/ze_desperate_soul.jsonc
@@ -33,11 +33,5 @@
     "templated": true,
     "timeout": 1.0,
     "breakable": "NPC_Ronka_Phys_2"
-  },
-  {
-    "name": "Spider Wall",
-    "multitrigger": true,
-    "showbeaten": false,
-    "breakable": "S4_G_Spider_Wall"
   }
 ]


### PR DESCRIPTION
Removes the health display of the spider wall on stage 5, which is a trigger and not an actual boss.