### PR TITLE
Add configs for ze_asiangirl_mm11el4nu4cp2io1yv7_r_p

### DIFF
--- a/bosshud/ze_asiangirl_mm11el4nu4cp2io1yv7_r_p.jsonc
+++ b/bosshud/ze_asiangirl_mm11el4nu4cp2io1yv7_r_p.jsonc
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "Object 1",
+    "breakable": "Boss_FL_RC1_hitbox"
+  },
+  {
+    "name": "Object 2",
+    "breakable": "Boss_FL_RC2_hitbox"
+  },
+  {
+    "name": "Object 3",
+    "breakable": "Boss_FL_RC3_hitbox"
+  },
+  {
+    "name": "Object 4",
+    "breakable": "Boss_FL_RC4_hitbox"
+  }
+]

--- a/entwatch/ze_asiangirl_mm11el4nu4cp2io1yv7_r_p.jsonc
+++ b/entwatch/ze_asiangirl_mm11el4nu4cp2io1yv7_r_p.jsonc
@@ -1,0 +1,47 @@
+[
+  {
+    "name": "Heal",
+    "shortname": "Heal",
+    "hammerid": "499",
+    "message": true,
+    "ui": true,
+    "transfer": true,
+    "color": "red"
+  },
+  {
+    "name": "Zombie Short Spear",
+    "shortname": "ZM S.Spear",
+    "hammerid": "329",
+    "message": true,
+    "ui": true,
+    "transfer": true,
+    "color": "grey"
+  },
+  {
+    "name": "Zombie Medium Spear",
+    "shortname": "ZM M.Spear",
+    "hammerid": "330",
+    "message": true,
+    "ui": true,
+    "transfer": true,
+    "color": "grey"
+  },
+  {
+    "name": "Zombie Long Spear",
+    "shortname": "ZM L.Spear",
+    "hammerid": "331",
+    "message": true,
+    "ui": true,
+    "transfer": true,
+    "color": "grey"
+  },
+  {
+    "name": "Zombie Very Long Spear",
+    "shortname": "ZM VL.Spear",
+    "hammerid": "332",
+    "message": true,
+    "ui": true,
+    "transfer": true,
+    "color": "grey"
+  }
+]


### PR DESCRIPTION
Adds bosshud and entwatch configs for ze_asiangirl_mm11el4nu4cp2io1yv7_r_p. Zombie items are C4, not knife, hence why `forcedrop` is set to true.