### PR TITLE
Update bosshud config for ze_cursed_bear_tales

### DIFF
--- a/bosshud/ze_cursed_bear_tales.jsonc
+++ b/bosshud/ze_cursed_bear_tales.jsonc
@@ -14,5 +14,12 @@
   {
     "name": "Bear",
     "breakable": "lvl3_boss_health02"
+  },
+  {
+    "hitmarkeronly": true,
+    "multitrigger": true,
+    "showbeaten": false,
+    "templated": true,
+    "breakable": "npc_health_biscuit"
   }
 ]


### PR DESCRIPTION
Adds hitmarker support for biscuit npc.