### PR TITLE
Update entwatch config for ze_rizomata_p

### DIFF
--- a/entwatch/ze_rizomata_p.jsonc
+++ b/entwatch/ze_rizomata_p.jsonc
@@ -1,357 +1,353 @@
 [
-    {
-        "name": "Heal 1",
-        "shortname": "Heal 1",
-        "hammerid": "1801",
+  {
+    "name": "Heal 1",
+    "shortname": "Heal 1",
+    "hammerid": "1801",
+    "message": true,
+    "ui": true,
+    "transfer": false,
+    "color": "white",
+    "triggers": ["1677"],
+    "handlers": [
+      {
+        "type": "button",
+        "hammerid": "1799"
+      },
+      {
+        "name": "Small",
+        "hammerid": "30823",
+        "event": "OnPass",
+        "mode": 2,
+        "cooldown": 55,
+        "maxuses": 0,
         "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "white",
-        "triggers": ["1677"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "1799"
-            },
-            {
-                "hammerid": "30823",
-                "event": "OnPass",
-                "mode": 2,
-                "cooldown": 55,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            },
-            {
-                "name": "Area",
-                "hammerid": "1809",
-                "event": "OnEqualTo",
-                "mode": 2,
-                "cooldown": 30,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Heal 2",
-        "shortname": "Heal 2",
-        "hammerid": "1594",
+        "ui": true
+      },
+      {
+        "name": "Large",
+        "hammerid": "1809",
+        "event": "OnEqualTo",
+        "mode": 2,
+        "cooldown": 30,
+        "maxuses": 0,
         "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "white",
-        "triggers": ["1577"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "1590"
-            },
-            {
-                "hammerid": "30825",
-                "event": "OnPass",
-                "mode": 2,
-                "cooldown": 55,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            },
-            {
-                "name": "Area",
-                "hammerid": "1588",
-                "event": "OnEqualTo",
-                "mode": 2,
-                "cooldown": 30,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Earth 1",
-        "shortname": "Earth 1",
-        "hammerid": "1816",
+        "ui": true
+      }
+    ]
+  },
+  {
+    "name": "Heal 2",
+    "shortname": "Heal 2",
+    "hammerid": "1594",
+    "message": true,
+    "ui": true,
+    "transfer": false,
+    "color": "white",
+    "triggers": ["1577"],
+    "handlers": [
+      {
+        "type": "button",
+        "hammerid": "1590"
+      },
+      {
+        "name": "Small",
+        "hammerid": "30825",
+        "event": "OnPass",
+        "mode": 2,
+        "cooldown": 55,
+        "maxuses": 0,
         "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "orange",
-        "triggers": ["1663"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "1817"
-            },
-            {
-                "hammerid": "30822",
-                "event": "OnPass",
-                "mode": 2,
-                "cooldown": 50,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            },
-            {
-                "name": "Small",
-                "hammerid": "1826",
-                "event": "OnEqualTo",
-                "mode": 2,
-                "cooldown": 10,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Earth 2",
-        "shortname": "Earth 2",
-        "hammerid": "1603",
+        "ui": true
+      },
+      {
+        "name": "Large",
+        "hammerid": "1588",
+        "event": "OnEqualTo",
+        "mode": 2,
+        "cooldown": 30,
+        "maxuses": 0,
         "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "orange",
-        "triggers": ["1575"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "1606",
-                "event": "OnPlayerUse",
-                "mode": 2,
-                "cooldown": 50,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            },
-            {
-                "hammerid": "30827",
-                "event": "OnPass",
-                "mode": 2,
-                "cooldown": 50,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            },
-            {
-                "name": "Small",
-                "hammerid": "1605",
-                "event": "OnEqualTo",
-                "mode": 2,
-                "cooldown": 10,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Water 1",
-        "shortname": "Water 1",
-        "hammerid": "1245",
+        "ui": true
+      }
+    ]
+  },
+  {
+    "name": "Earth 1",
+    "shortname": "Earth 1",
+    "hammerid": "1816",
+    "message": true,
+    "ui": true,
+    "transfer": false,
+    "color": "orange",
+    "triggers": ["1663"],
+    "handlers": [
+      {
+        "type": "button",
+        "hammerid": "1817"
+      },
+      {
+        "name": "Large",
+        "hammerid": "30822",
+        "event": "OnPass",
+        "mode": 2,
+        "cooldown": 50,
+        "maxuses": 0,
         "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "darkblue",
-        "triggers": ["1278"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "1239"
-            },
-            {
-                "hammerid": "30820",
-                "event": "OnPass",
-                "mode": 2,
-                "cooldown": 50,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            },
-            {
-                "name": "Slow",
-                "hammerid": "1246",
-                "event": "OnEqualTo",
-                "mode": 2,
-                "cooldown": 40,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Water 2",
-        "shortname": "Water 2",
-        "hammerid": "1264",
+        "ui": true
+      },
+      {
+        "name": "Small",
+        "hammerid": "1826",
+        "event": "OnEqualTo",
+        "mode": 2,
+        "cooldown": 10,
+        "maxuses": 0,
         "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "darkblue",
-        "triggers": ["1284"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "1258"
-            },
-            {
-                "hammerid": "30829",
-                "event": "OnPass",
-                "mode": 2,
-                "cooldown": 50,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            },
-            {
-                "name": "Slow",
-                "hammerid": "1265",
-                "event": "OnEqualTo",
-                "mode": 2,
-                "cooldown": 40,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Wind 1",
-        "shortname": "Wind 1",
-        "hammerid": "703",
+        "ui": true
+      }
+    ]
+  },
+  {
+    "name": "Earth 2",
+    "shortname": "Earth 2",
+    "hammerid": "1603",
+    "message": true,
+    "ui": true,
+    "transfer": false,
+    "color": "orange",
+    "triggers": ["1575"],
+    "handlers": [
+      {
+        "type": "button",
+        "hammerid": "1606"
+      },
+      {
+        "name": "Large",
+        "hammerid": "30827",
+        "event": "OnPass",
+        "mode": 2,
+        "cooldown": 50,
+        "maxuses": 0,
         "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "green",
-        "triggers": ["784"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "698"
-            },
-            {
-                "hammerid": "30818",
-                "event": "OnPass",
-                "mode": 2,
-                "cooldown": 50,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            },
-            {
-                "name": "Laser",
-                "hammerid": "701",
-                "event": "OnEqualTo",
-                "mode": 2,
-                "cooldown": 20,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Wind 2",
-        "shortname": "Wind 2",
-        "hammerid": "667",
+        "ui": true
+      },
+      {
+        "name": "Small",
+        "hammerid": "1605",
+        "event": "OnEqualTo",
+        "mode": 2,
+        "cooldown": 10,
+        "maxuses": 0,
         "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "green",
-        "triggers": ["746"],
-        "handlers": [
-            {
-                "type": "button",
-                "hammerid": "660",
-                "event": "OnPlayerUse",
-                "mode": 2,
-                "cooldown": 50,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            },
-            {
-                "hammerid": "30831",
-                "event": "OnPass",
-                "mode": 2,
-                "cooldown": 50,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            },
-            {
-                "name": "Laser",
-                "hammerid": "669",
-                "event": "OnEqualTo",
-                "mode": 2,
-                "cooldown": 20,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Death",
-        "shortname": "ZM Death",
-        "hammerid": "732",
+        "ui": true
+      }
+    ]
+  },
+  {
+    "name": "Water 1",
+    "shortname": "Water 1",
+    "hammerid": "1245",
+    "message": true,
+    "ui": true,
+    "transfer": false,
+    "color": "darkblue",
+    "triggers": ["1278"],
+    "handlers": [
+      {
+        "type": "button",
+        "hammerid": "1239"
+      },
+      {
+        "name": "Ice",
+        "hammerid": "30820",
+        "event": "OnPass",
+        "mode": 2,
+        "cooldown": 50,
+        "maxuses": 0,
         "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "purple",
-        "triggers": ["733"],
-        "handlers": [
-            {
-                "hammerid": "719",
-                "event": "OnTrigger",
-                "mode": 2,
-                "cooldown": 10,
-                "maxuses": 0,
-                "message": false,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Haste",
-        "shortname": "ZM Haste",
-        "hammerid": "738",
+        "ui": true
+      },
+      {
+        "name": "Bubble",
+        "hammerid": "1246",
+        "event": "OnEqualTo",
+        "mode": 2,
+        "cooldown": 40,
+        "maxuses": 0,
         "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "green",
-        "triggers": ["739"],
-        "handlers": [
-            {
-                "hammerid": "720",
-                "event": "OnTrigger",
-                "mode": 2,
-                "cooldown": 30,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    },
-    {
-        "name": "Zombie Curse",
-        "shortname": "ZM Curse",
-        "hammerid": "735",
+        "ui": true
+      }
+    ]
+  },
+  {
+    "name": "Water 2",
+    "shortname": "Water 2",
+    "hammerid": "1264",
+    "message": true,
+    "ui": true,
+    "transfer": false,
+    "color": "darkblue",
+    "triggers": ["1284"],
+    "handlers": [
+      {
+        "type": "button",
+        "hammerid": "1258"
+      },
+      {
+        "name": "Ice",
+        "hammerid": "30829",
+        "event": "OnPass",
+        "mode": 2,
+        "cooldown": 50,
+        "maxuses": 0,
         "message": true,
-        "ui": true,
-        "transfer": false,
-        "color": "grey",
-        "triggers": ["736"],
-        "handlers": [
-            {
-                "hammerid": "721",
-                "event": "OnTrigger",
-                "mode": 2,
-                "cooldown": 60,
-                "maxuses": 0,
-                "message": true,
-                "ui": true
-            }
-        ]
-    }
+        "ui": true
+      },
+      {
+        "name": "Bubble",
+        "hammerid": "1265",
+        "event": "OnEqualTo",
+        "mode": 2,
+        "cooldown": 40,
+        "maxuses": 0,
+        "message": true,
+        "ui": true
+      }
+    ]
+  },
+  {
+    "name": "Wind 1",
+    "shortname": "Wind 1",
+    "hammerid": "703",
+    "message": true,
+    "ui": true,
+    "transfer": false,
+    "color": "green",
+    "triggers": ["784"],
+    "handlers": [
+      {
+        "type": "button",
+        "hammerid": "698"
+      },
+      {
+        "name": "Push",
+        "hammerid": "30818",
+        "event": "OnPass",
+        "mode": 2,
+        "cooldown": 50,
+        "maxuses": 0,
+        "message": true,
+        "ui": true
+      },
+      {
+        "name": "Laser",
+        "hammerid": "701",
+        "event": "OnEqualTo",
+        "mode": 2,
+        "cooldown": 20,
+        "maxuses": 0,
+        "message": true,
+        "ui": true
+      }
+    ]
+  },
+  {
+    "name": "Wind 2",
+    "shortname": "Wind 2",
+    "hammerid": "667",
+    "message": true,
+    "ui": true,
+    "transfer": false,
+    "color": "green",
+    "triggers": ["746"],
+    "handlers": [
+      {
+        "type": "button",
+        "hammerid": "660"
+      },
+      {
+        "name": "Push",
+        "hammerid": "30831",
+        "event": "OnPass",
+        "mode": 2,
+        "cooldown": 50,
+        "maxuses": 0,
+        "message": true,
+        "ui": true
+      },
+      {
+        "name": "Laser",
+        "hammerid": "669",
+        "event": "OnEqualTo",
+        "mode": 2,
+        "cooldown": 20,
+        "maxuses": 0,
+        "message": true,
+        "ui": true
+      }
+    ]
+  },
+  {
+    "name": "Zombie Death",
+    "shortname": "ZM Death",
+    "hammerid": "732",
+    "message": true,
+    "ui": true,
+    "transfer": false,
+    "color": "purple",
+    "triggers": ["733"],
+    "handlers": [
+      {
+        "hammerid": "719",
+        "event": "OnTrigger",
+        "mode": 2,
+        "cooldown": 10,
+        "maxuses": 0,
+        "message": false,
+        "ui": true
+      }
+    ]
+  },
+  {
+    "name": "Zombie Haste",
+    "shortname": "ZM Haste",
+    "hammerid": "738",
+    "message": true,
+    "ui": true,
+    "transfer": false,
+    "color": "green",
+    "triggers": ["739"],
+    "handlers": [
+      {
+        "hammerid": "720",
+        "event": "OnTrigger",
+        "mode": 2,
+        "cooldown": 30,
+        "maxuses": 0,
+        "message": true,
+        "ui": true
+      }
+    ]
+  },
+  {
+    "name": "Zombie Curse",
+    "shortname": "ZM Curse",
+    "hammerid": "735",
+    "message": true,
+    "ui": true,
+    "transfer": false,
+    "color": "grey",
+    "triggers": ["736"],
+    "handlers": [
+      {
+        "hammerid": "721",
+        "event": "OnTrigger",
+        "mode": 2,
+        "cooldown": 60,
+        "maxuses": 0,
+        "message": true,
+        "ui": true
+      }
+    ]
+  }
 ]


### PR DESCRIPTION
This pull requests accomplishes the following for ze_rizomata_p entwatch config:
1. Fixes duplicate cooldown display from buttons on wind and earth.
2. Adds and updates ability names for human items.