### PR TITLE
Add configs for ze_overkill_p

### DIFF
--- a/bosshud/ze_overkill_p.jsonc
+++ b/bosshud/ze_overkill_p.jsonc
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "Dogma Resistance",
+    "counter": "dogma_s_boss_hp"
+  },
+  {
+    "name": "Overkill",
+    "counter": "overkill_s_boss_hp"
+  }
+]

--- a/cs2fixes/adminroom.jsonc
+++ b/cs2fixes/adminroom.jsonc
@@ -56,6 +56,7 @@
     "ze_omen_cs2": [-12802, -5069, 832],
     "ze_omochi_cs2": [2624, -2816, 64],
     "ze_onahole_p": [0, 0, -72],
+    "ze_overkill_p": [-90, -92, -32],
     "ze_parking_p": [-1470, 2480, 148],
     "ze_payload_swarm": [9223, 352, 376],
     "ze_permafrost": [6546, 14530, 0],

--- a/entwatch/ze_overkill_p.jsonc
+++ b/entwatch/ze_overkill_p.jsonc
@@ -1,0 +1,82 @@
+[
+  {
+    "name": "Health Box",
+    "shortname": "Heal",
+    "hammerid": "734",
+    "message": true,
+    "ui": true,
+    "transfer": true,
+    "color": "green",
+    "handlers": [
+      {
+        "hammerid": "100876",
+        "event": "OnTrigger",
+        "mode": 2,
+        "cooldown": 45,
+        "maxuses": 0,
+        "message": true,
+        "ui": true
+      }
+    ]
+  },
+  {
+    "name": "Molotov",
+    "shortname": "Molotov",
+    "hammerid": "664",
+    "message": true,
+    "ui": true,
+    "transfer": true,
+    "color": "orange",
+    "handlers": [
+      {
+        "type": "counterup",
+        "hammerid": "92640",
+        "mode": 3,
+        "cooldown": 30,
+        "ui": true,
+        "message": true
+      }
+    ]
+  },
+  {
+    "name": "Dogma Resistance",
+    "shortname": "Dogma",
+    "hammerid": "1231",
+    "message": true,
+    "ui": true,
+    "transfer": true,
+    "color": "red",
+    "handlers": [
+      {
+        "hammerid": "100878",
+        "event": "OnTrigger",
+        "mode": 3,
+        "cooldown": 0,
+        "maxuses": 1,
+        "message": true,
+        "ui": true
+      }
+    ]
+  },
+  {
+    "name": "Zombie Freeze Beam",
+    "shortname": "Zombie Freeze",
+    "hammerid": "742",
+    "message": true,
+    "ui": true,
+    "transfer": false,
+    "color": "blue",
+    "triggers": ["9984"],
+    "handlers": [
+      {
+        "hammerid": "100877",
+        "event": "OnTrigger",
+        "mode": 2,
+        "cooldown": 60,
+        "maxuses": 0,
+        "message": true,
+        "ui": true
+      }
+    ]
+  }
+]

--- a/musicname/ze_overkill_p.jsonc
+++ b/musicname/ze_overkill_p.jsonc
@@ -1,0 +1,17 @@
+{
+  "music.04_wind_blows": "FELT - Wind blows...",
+  "music.01_nagi_candor": "NAGI - Candor",
+  "music.02_underwater_jungle": "Nor - Underwater Jungle (Blue Archive OST)",
+  "music.liquicity-cold_green_eyes": "Station Earth - Cold Green Eyes",
+  "music.alkaline_tears": "Mitsukiyo - Alkaline Tears",
+  "music.agony_converging_into_river": "HOYO MiX - Agony Converging into River (Honkai: Star Rail OST)",
+  "music.agony_converging_into_river_02": "HOYO MiX - Agony Converging into River (Honkai: Star Rail OST)",
+  "music.polyphonic": "Nor - Polyphonic (Blue Archive OST)",
+  "music.nor_responsibility": "Nor - Responsibility (Blue Archive OST)",
+  "music.overkill_01": "RIOT - Overkill",
+  "music.overkill_02": "RIOT - Overkill",
+  "music.overkill_03": "RIOT - Overkill",
+  "music.overkill_04": "RIOT - Overkill",
+  "music.overkill_05": "RIOT - Overkill",
+  "music.overkill_last": "RIOT - Overkill"
+}


### PR DESCRIPTION
Adds adminroom, bosshud, entwatch, and musicname configs for ze_overkill_p. Items use script detection so no buttons to track.