### PR TITLE
Add configs for ze_exit_this_earths_atomosphere_p

### DIFF
--- a/entwatch/ze_exit_this_earths_atomosphere_p.jsonc
+++ b/entwatch/ze_exit_this_earths_atomosphere_p.jsonc
@@ -1,0 +1,41 @@
+[
+  {
+    "name": "Asteroid Destroyer Pulse",
+    "shortname": "ADP",
+    "hammerid": "893",
+    "message": true,
+    "ui": true,
+    "transfer": true,
+    "color": "green",
+    "handlers": [
+      {
+        "type": "counterup",
+        "hammerid": "56720",
+        "mode": 3,
+        "cooldown": 4,
+        "ui": true,
+        "message": true
+      }
+    ]
+  },
+  {
+    "name": "Meter Apocalypse Destroyer",
+    "shortname": "MAD",
+    "hammerid": "345",
+    "message": true,
+    "ui": true,
+    "transfer": true,
+    "color": "red",
+    "handlers": [
+      {
+        "hammerid": "56742",
+        "event": "OnTrigger",
+        "mode": 3,
+        "cooldown": 0,
+        "maxuses": 1,
+        "message": true,
+        "ui": true
+      }
+    ]
+  }
+]

--- a/musicname/ze_exit_this_earths_atomosphere_p.jsonc
+++ b/musicname/ze_exit_this_earths_atomosphere_p.jsonc
@@ -1,0 +1,6 @@
+{
+  "music.etea intro mono": "Camellia - Exit This Earth's Atomosphere",
+  "music.etea full half1": "Camellia - Exit This Earth's Atomosphere",
+  "music.etea 200 half2": "Camellia - Exit This Earth's Atomosphere (200Step Remix)",
+  "music.etea 200 chorus": "Camellia - Exit This Earth's Atomosphere (200Step Remix)"
+}


### PR DESCRIPTION
Adds entwatch and musicname configs for ze_exit_this_earths_atomosphere_p. Items use script detection for usage so no buttons.